### PR TITLE
ENG-457: add catppuccin expressive code themes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-
+import mocha from '@catppuccin/vscode/themes/mocha.json'
+import latte from '@catppuccin/vscode/themes/latte.json'
 // https://astro.build/config
 export default defineConfig({
 	integrations: [
@@ -535,7 +536,7 @@ export default defineConfig({
 				},
 			],
 			expressiveCode: {
-				themes: ["dracula", "rose-pine-dawn"],
+				themes: [mocha, latte],
 			},
 		}),
 	],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/starlight": "^0.23.2",
+        "@catppuccin/vscode": "^3.15.1",
         "astro": "^4.8.6",
         "sharp": "^0.32.5",
         "typescript": "^5.4.5"
@@ -877,6 +878,29 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@catppuccin/palette": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@catppuccin/palette/-/palette-1.2.0.tgz",
+      "integrity": "sha512-R5fxLcU47mRcsdQkXZBNfxt7SdEqLGWb1qhEKBrnYfEB4ZWOQRBEow4e78PKxaFUECBNOs6uEkwvwxFL9FmQqQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/catppuccin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/catppuccin"
+        }
+      ]
+    },
+    "node_modules/@catppuccin/vscode": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@catppuccin/vscode/-/vscode-3.15.1.tgz",
+      "integrity": "sha512-2y5LpSom0SytZTy/Jyu02qK+V1Uyzk9xlCVwDmmm08CI4nPCuVnOccQmaq83vUpZ/r3sdhWF6Aa3XF+ahfz00g==",
+      "dependencies": {
+        "@catppuccin/palette": "^1.1.1"
       }
     },
     "node_modules/@ctrl/tinycolor": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/check": "^0.7.0",
     "@astrojs/starlight": "^0.23.2",
+    "@catppuccin/vscode": "^3.15.1",
     "astro": "^4.8.6",
     "sharp": "^0.32.5",
-    "@astrojs/check": "^0.7.0",
     "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
# ℹ️ Overview

- adds `@catppuccin/vscode` as dependency
- applies `mocha` and `latte` themes to expressive code configuration of Starlight

# 📝 Issues

- https://algorandfoundation.atlassian.net/browse/ENG-457


