### PR TITLE
Added Code Markers

### DIFF
--- a/src/components/CodeMarker.astro
+++ b/src/components/CodeMarker.astro
@@ -1,0 +1,9 @@
+---
+import { Code } from '@astrojs/starlight/components';
+import { getSelectedCode } from './CodeMarker';
+
+const { src, marker, lang, title, mark, frame } = Astro.props;
+const selectedCode = await getSelectedCode(src, marker);
+---
+
+<Code code={selectedCode} lang={lang} title={title} frame={frame} mark={mark} />

--- a/src/components/CodeMarker.ts
+++ b/src/components/CodeMarker.ts
@@ -1,0 +1,52 @@
+import fs from 'fs/promises';
+import { URL } from 'url';
+
+export async function getSelectedCode(
+  src: string,
+  marker: string | undefined,
+): Promise<string> {
+  const code = await getCode(src);
+
+  if (!marker) {
+    return code;
+  }
+
+  const pattern = `^ *(//|#) example: ${marker}$`
+  const regex = new RegExp(pattern, 'g');
+  const codeLines = code.split('\n');
+
+  const occurrenceIndexes = codeLines.reduce<number[]>((indexes, line, index) => {
+    if (regex.test(line)) {
+      indexes.push(index);
+    }
+    return indexes;
+  }, []);
+
+  if (occurrenceIndexes.length !== 2) {
+    throw new Error(`Error: Pattern "${pattern}" must occur exactly twice. Found: ${occurrenceIndexes.length}`);
+  }
+
+  const [startIndex, endIndex] = occurrenceIndexes;
+  return codeLines.slice(startIndex + 1, endIndex).join('\n');
+}
+
+async function getCode(src: string): Promise<string> {
+  try {
+    new URL(src);
+    const response = await fetch(src);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return await response.text();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      try {
+        return await fs.readFile(src, 'utf-8');
+      } catch (fsError: any) {
+        throw new Error(`Error reading file: ${fsError.message}`);
+      }
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Accepts a `src` string that can be a local path or a remote URI.

Optional `marker` mimics the format of the old docs, e.g. marker `LALA`:
```
// example: LALA
I will be extracted! 👍
// example: LALA
```
`marker` has to occur exactly twice.

Usage:
```
import Code from '/src/components/CodeMarker.astro';

<Code src="https://raw.githubusercontent.com/algorand/java-algorand-sdk/examples/examples/src/main/java/com/algorand/examples/CodecExamples.java" marker="CODEC_ADDRESS" />
```
Will return
```
        String addrAsStr = "4H5UNRBJ2Q6JENAXQ6HNTGKLKINP4J4VTQBEPK5F3I6RDICMZBPGNH6KD4";
        // Instantiate a new Address object with string
        Address addr = new Address(addrAsStr);
        // Or with the bytes
        Address addrAgain = new Address(addr.getBytes());
        assert addrAgain.equals(addr);
```