### PR TITLE
Dvp 74 inner transactions

### DIFF
--- a/src/content/docs/build/smart_contracts/inner-transaction.mdx
+++ b/src/content/docs/build/smart_contracts/inner-transaction.mdx
@@ -6,7 +6,7 @@ draft: true
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { Code } from '@astrojs/starlight/components';
-import CodeMarker from '/src/components/CodeMarker.astro';
+import RemoteCode from '/src/components/RemoteCode.astro';
 
 ## What is Inner Transaction?
 
@@ -55,9 +55,9 @@ To illustrate this concept, let's examine a payment Inner Transaction example th
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='PAYMENT'
+      snippet='PAYMENT'
       lang='py'
       title='Payment Inner Transaction'
       frame='none'
@@ -72,9 +72,9 @@ Assets can be created by a smart contract. Use the following contract code to cr
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_CREATE'
+      snippet='ASSET_CREATE'
       lang='py'
       title='Asset Create Inner Transaction'
       frame='none'
@@ -89,9 +89,9 @@ If a smart contract wishes to transfer an asset it holds or needs to opt into an
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_OPT_IN'
+      snippet='ASSET_OPT_IN'
       lang='py'
       title='Asset Opt-In Inner Transaction'
       frame='none'
@@ -106,9 +106,9 @@ If a smart contract is opted into the asset (ASA), it can transfer the asset wit
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_TRANSFER'
+      snippet='ASSET_TRANSFER'
       lang='py'
       title='Asset Transfer Inner Transaction'
       frame='none'
@@ -123,9 +123,9 @@ A smart contract can freeze any asset, where the smart contract is set as the fr
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_FREEZE'
+      snippet='ASSET_FREEZE'
       lang='py'
       title='Asset Freeze Inner Transaction'
       frame='none'
@@ -140,9 +140,9 @@ A smart contract can revoke or clawback any asset where the smart contract addre
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_REVOKE'
+      snippet='ASSET_REVOKE'
       lang='py'
       title='Asset Clawback Inner Transaction'
       frame='none'
@@ -157,9 +157,9 @@ As with all assets, the mutable addresses can be changed using contract code sim
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_CONFIG'
+      snippet='ASSET_CONFIG'
       lang='py'
       title='Asset Config Inner Transaction'
       frame='none'
@@ -174,9 +174,9 @@ Assets managed by the contract can also be deleted. This can be done with the fo
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='ASSET_DELETE'
+      snippet='ASSET_DELETE'
       lang='py'
       title='Asset Delete Inner Transaction'
       frame='none'
@@ -191,9 +191,9 @@ A smart contract can make inner transactions consisting of multiple transactions
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='GROUPED_INNER_TXNS'
+      snippet='GROUPED_INNER_TXNS'
       lang='py'
       title='Multiple Inner Transaction Atomically'
       frame='none'
@@ -209,7 +209,7 @@ A smart contract can also call another smart contract method with inner transact
 - An application may not call itself, even indirectly. This is referred to as re-entrancy and is explicitly forbidden.
 - An application may only call into other applications up to a stack depth of 8. In other words, if app calls (->) look like 1->2->3->4->5->6->7->8, App 8 may not call another application. This would violate the stack depth limit.
 - An application may issue up to 256 inner transactions to increase its budget (max budget of 179.2k even for a group size of 1), but the max call budget is shared for all applications in the group. This means you can't have two app calls in the same group that both try to issue 256 inner app calls.
-- An application of program version 6 or above may not call contracts with a program version 3 or below. This limitation protects an older application from unexpected behavior introduced in newer program versions.
+- An application of AVM version 6 or above may not call contracts with a AVM version 3 or below. This limitation protects an older application from unexpected behavior introduced in newer AVM versions.
 
 A smart contract can call other smart contracts using any of the OnComplete types. This allows a smart contract to create, opt in, close out, clear state, delete, or just call (NoOp) other smart contracts. To call an existing smart contract the following contract code can be used.
 
@@ -217,9 +217,9 @@ A smart contract can call other smart contracts using any of the OnComplete type
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='NOOP_APP_CALL'
+      snippet='NOOP_APP_CALL'
       lang='py'
       title='NoOp App Call Inner Transaction'
       frame='none'
@@ -232,9 +232,9 @@ A smart contract can call other smart contracts using any of the OnComplete type
 
 <Tabs syncKey='lang'>
   <TabItem label='Python' icon='seti:python'>
-    <CodeMarker
+    <RemoteCode
       src='https://raw.githubusercontent.com/algorand-devrel/new-devportal-code-examples/main/projects/devportal-code-examples/smart_contracts/inner_transactions/contract.py'
-      marker='DEPLOY_APP'
+      snippet='DEPLOY_APP'
       lang='py'
       title='Deploy App With Inner Transaction'
       frame='none'


### PR DESCRIPTION
# ℹ Overview
- Inner Transaction Page
- First page to implement importing in code snippets using CodeMarker by @lazystar https://github.com/algorandfoundation/devportal/pull/75


### 📝 Related Issues
- If this approach looks good, we should work on a contribution guide for https://github.com/algorand-devrel/new-devportal-code-examples/tree/main and add all code examples in this repo and import them to the dev portal. The examples in this repo should be runnable with integration tests.