### PR TITLE
Updated deployment action to post PR preview URL to Slack

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,6 +63,7 @@ jobs:
       # Step 9: Post the Preview URL, PR ID, and PR Title to Slack
       - name: Post to Slack
         id: slack
+        if: github.event_name == 'pull_request'
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |


### PR DESCRIPTION
# ℹ Overview

Updated deployment action to post PR preview URL to Slack, using a payload of PR ID, PR Title, and Preview Url.

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Lint passes