### PR TITLE
DVP-366: Integration of Plausible.io analytics to prod

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,15 @@ export default defineConfig({
           exclude: ['**[FUTURELINK]*', '**/reference/**'],
         }),
       ],
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            'data-domain': 'developer.algorand.co',
+            src: 'https://plausible.io/js/script.hash.outbound-links.tagged-events.js',
+          },
+        },
+      ],
       components: {
         ThemeProvider: './src/components/CustomThemeProvider.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',


### PR DESCRIPTION
# ℹ Overview

 Integration of Plausible.io analytics to prod so that we can further configure the analytics capture config

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [X] Lint passes