### PR TITLE
Add Scalar to API Overview Page / Organize api doc in side bar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -253,6 +253,10 @@ export default defineConfig({
                   link: 'concepts/smart-contracts/control-flow',
                 },
                 {
+                  label: 'Inner Transactions',
+                  link: 'concepts/smart-contracts/inner-txn',
+                },
+                {
                   label: 'Resource Usage',
                   link: 'concepts/smart-contracts/resource-usage',
                 },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,6 +28,12 @@ export default defineConfig({
             schema:
               'https://raw.githubusercontent.com/algorand/go-algorand/refs/heads/master/daemon/algod/api/algod.oas3.yml',
             collapsed: true,
+            sidebar: {
+              operations: {
+                sort: "alphabetical",
+                labels: "operationId",
+              },
+            },
           },
           {
             base: 'reference/rest-api/indexer',
@@ -35,6 +41,12 @@ export default defineConfig({
             schema:
               'https://raw.githubusercontent.com/algorand/indexer/refs/heads/main/api/indexer.oas3.yml',
             collapsed: true,
+            sidebar: {
+              operations: {
+                sort: "alphabetical",
+                labels: "operationId",
+              },
+            },
           },
           {
             base: 'reference/rest-api/kmd',
@@ -42,6 +54,12 @@ export default defineConfig({
             schema:
               'https://raw.githubusercontent.com/algorand/go-algorand/ad578576ab5f5bfe58a590164903617ecef379e4/daemon/kmd/api/swagger.json',
             collapsed: true,
+            sidebar: {
+              operations: {
+                sort: "alphabetical",
+                labels: "operationId",
+              },
+            },
           },
         ]),
       ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -137,6 +137,10 @@ export default defineConfig({
                   link: 'concepts/transactions/types',
                 },
                 {
+                  label: 'Fees',
+                  link: 'concepts/transactions/fees',
+                },
+                {
                   label: 'Atomic Transaction Groups',
                   link: 'concepts/transactions/atomic-txn-groups',
                 },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sharp": "^0.32.5",
     "starlight-image-zoom": "^0.11.1",
     "starlight-links-validator": "^0.12.1",
-    "starlight-openapi": "^0.13.0",
+    "starlight-openapi": "^0.14.1",
     "starlight-typedoc": "^0.17.0",
     "tailwindcss": "^3.4.4",
     "typedoc": "^0.27.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.12.1
         version: 0.12.4(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))
       starlight-openapi:
-        specifier: ^0.13.0
-        version: 0.13.0(@astrojs/markdown-remark@6.1.0)(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))(openapi-types@12.1.3)
+        specifier: ^0.14.1
+        version: 0.14.1(@astrojs/markdown-remark@6.1.0)(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))(openapi-types@12.1.3)
       starlight-typedoc:
         specifier: ^0.17.0
         version: 0.17.0(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.5.2)))(typedoc@0.27.6(typescript@5.5.2))
@@ -912,8 +912,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@readme/better-ajv-errors@2.2.2':
-    resolution: {integrity: sha512-YBWor3QZhavGHqTEHJfYfk2e0UczQaImc0MIIJ5JNJrns4HKm94pwUdjkPVZO2eZJBt/Rzs/D8ZrdvFFwRh0zQ==}
+  '@readme/better-ajv-errors@2.3.2':
+    resolution: {integrity: sha512-T4GGnRAlY3C339NhoUpgJJFsMYko9vIgFAlhgV+/vEGFw66qEY4a4TRJIAZBcX/qT1pq5DvXSme+SQODHOoBrw==}
     engines: {node: '>=18'}
     peerDependencies:
       ajv: 4.11.8 - 8
@@ -3331,8 +3331,8 @@ packages:
       '@astrojs/starlight': '>=0.15.0'
       astro: '>=4.0.0'
 
-  starlight-openapi@0.13.0:
-    resolution: {integrity: sha512-X2QrMFaNuLiURABwSVdU/XgpQgXE1lBKLpci16aJywkYpgcUHDJwVVIQIEMYDWsApxd8ElVsv3AtzTVlWbNOlA==}
+  starlight-openapi@0.14.1:
+    resolution: {integrity: sha512-hCmeNR2KA0RrvJMjewPmqmHSY470TobyU1PDKDbwbHMbP0OcYxD36pTOTXkWFxdSnIQc7WPC0jc8trMNzb3/tw==}
     engines: {node: '>=18.17.1'}
     peerDependencies:
       '@astrojs/markdown-remark': '>=6.0.1'
@@ -4768,7 +4768,7 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@readme/better-ajv-errors@2.2.2(ajv@8.17.1)':
+  '@readme/better-ajv-errors@2.3.2(ajv@8.17.1)':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.26.0
@@ -4789,7 +4789,7 @@ snapshots:
     dependencies:
       '@apidevtools/swagger-methods': 3.0.2
       '@jsdevtools/ono': 7.1.3
-      '@readme/better-ajv-errors': 2.2.2(ajv@8.17.1)
+      '@readme/better-ajv-errors': 2.3.2(ajv@8.17.1)
       '@readme/json-schema-ref-parser': 1.2.0
       '@readme/openapi-schemas': 3.1.0
       ajv: 8.17.1
@@ -7939,7 +7939,7 @@ snapshots:
       picomatch: 4.0.2
       unist-util-visit: 5.0.0
 
-  starlight-openapi@0.13.0(@astrojs/markdown-remark@6.1.0)(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))(openapi-types@12.1.3):
+  starlight-openapi@0.14.1(@astrojs/markdown-remark@6.1.0)(@astrojs/starlight@0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0)))(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))(openapi-types@12.1.3):
     dependencies:
       '@astrojs/markdown-remark': 6.1.0
       '@astrojs/starlight': 0.32.1(astro@5.3.1(@types/node@22.12.0)(jiti@2.3.3)(rollup@4.34.8)(tsx@4.19.2)(typescript@5.5.2)(yaml@2.7.0))

--- a/src/content/docs/concepts/transactions/fees.mdx
+++ b/src/content/docs/concepts/transactions/fees.mdx
@@ -1,6 +1,11 @@
 ---
 title: Transaction Fees
+draft: true
 ---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Code } from '@astrojs/starlight/components';
+import RemoteCode from '/src/components/RemoteCode.astro';
 
 Blockchains like Algorand are decentralized networks with finite computational resources. Transaction fees serve as an essential economic mechanism to protect the network by requiring users to pay for the computational resources their transactions use. This fee structure protects Algorand against potential spam attacks that could overwhelm the system and prevent the blockchain from being trapped in infinite computational loops that compromise performance and security.
 
@@ -9,8 +14,10 @@ Blockchains like Algorand are decentralized networks with finite computational r
 The minimum fee for each transaction on Algorand is 1000 microAlgo or 0.001 Algo, and it is **fixed** to this amount when the network is not congested.
 
 ## Fee Calculation Formula
-
-For a transaction that has been serialized into bytes (`txn_in_bytes`) and given the current network's congestion-based fee per byte (`fee_per_byte`), the total transaction fee is calculated using this formula:
+The total fee of a transaction is calculated using the following formula where:
+- `txn_in_bytes` is the size of the transaction in bytes
+- `fee_per_byte` is the current network's congestion-based fee per byte
+- `min_fee` is the minimum fee for a transaction
 
 ```shell showLineNumbers=false frame=none title="Fee Calculation"
 fee = max(current_fee_per_byte*len(txn_in_bytes), min_fee)
@@ -24,7 +31,7 @@ Transaction fees in Algorand apply uniformly across all transaction types—paym
 
 ## Suggested Fee
 
-The [algod REST server](FUTURELINK: link to algod REST server page) provides `suggestedParams` that include the suggested `current fee per byte`. This suggested fee is used to determines transaction costs through this simple formula:
+The [algod REST server](/reference/rest-api/overview) provides [suggestedParams](/reference/rest-api/algod/operations/transactionparams#200) that include the `fee` parameter which is the suggested `current fee per byte`. This suggested fee is used to determines transaction costs through this simple formula:
 
 ```shell showLineNumbers=false frame=none title="Fee Calculation"
 fee = max(current_fee_per_byte * transaction_size_in_bytes, min_fee)
@@ -38,11 +45,22 @@ fee = max(0, min_fee) = min_fee
 
 This is why standard Algorand transactions cost **0.001 ALGO** or **1000 microAlgo** during normal network conditions.
 
-:::note
-When using suggested fees, always set a maximum fee limit. During network congestion, fees become variable and could increase significantly based on network conditions.
-:::
+Here is an example of how to get suggested parameters using the Algorand Client.
 
-#code example
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'>
+  </TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    {/* <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
+      snippet='MAX_FEE'
+      lang='py'
+      title='Set a maximum fee limit'
+      frame='none'
+    />   */}
+  </TabItem>
+</Tabs>
+
 
 ### Algorand Client Suggested Params Configuration
 
@@ -53,11 +71,29 @@ The [Algorand Client](FUTURELINK:link_to_algorand_client_page) caches suggested 
 - `algorand.setSuggestedParamsTimeout(timeout)` - Set the timeout that is used to cache the suggested network parameters (by default 3 seconds)
 - `algorand.getSuggestedParams()` - Get the current suggested network parameters object, either the cached value, or if the cache has expired a fresh value
 
+:::caution
+When using suggested fees, always set a maximum fee limit. During network congestion, fees become variable and could increase significantly based on network conditions.
+
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'>
+  </TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    {/* <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
+      snippet='MAX_FEE'
+      lang='py'
+      title='Set a maximum fee limit'
+      frame='none'
+    />   */}
+  </TabItem>
+</Tabs>
+:::
+
 ## Flat Fee
 
-The suggested parameters include a flat fee field that enables manual fee configuration. When set to true, you can specify exactly how much you want to pay for a transaction.
+The suggested parameters include a `flat_fee` field that enables manual fee configuration. When set to `true`, you can specify exactly how much you want to pay for a transaction.
 
-If you choose this method, ensure your specified fee meets at least the minimum transaction fee (min-fee) available in the suggested parameters through the Algorand Client.
+If you choose this method, ensure your specified fee meets at least the minimum transaction fee (`min-fee`) available in the suggested parameters through the Algorand Client.
 
 ### Use Cases for Flat Fees
 
@@ -66,9 +102,23 @@ If you choose this method, ensure your specified fee meets at least the minimum 
 - Preparing future transactions when network conditions are unknown
 - Handling non-urgent transactions that can be retried if rejected
 
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'>
+  </TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    {/* <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
+      snippet='MAX_FEE'
+      lang='py'
+      title='Set a maximum fee limit'
+      frame='none'
+    />   */}
+  </TabItem>
+</Tabs>
+
 ## Pooled transaction fees
 
-The Algorand protocol supports pooled fees, where one transaction can pay the fees of other transactions within the same [atomic group](FUTURELINK:link-to-atomic-group).
+The Algorand protocol supports pooled fees, where one transaction can pay the fees of other transactions within the same [atomic group](/concepts/transactions/atomic-txn-groups).
 
 For atomic transactions, the fees set on all transactions in the group are summed. This sum is compared against the protocol determined expected fee for the group and may proceed as long as the sum of the fees is greater than or equal to the required fee for the group.
 
@@ -77,16 +127,30 @@ For atomic transactions, the fees set on all transactions in the group are summe
 
 Below is an example of setting a pooled fee on an atomic group of two transactions. Here transaction B's fee is directly set to be 2x the minimum fee and transaction A's fee is set to zero. This atomic group will successfully execute because the sum of the fees is greater than or equal to the required fee for the group.
 
-#code example
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'>
+  </TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    {/* <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
+      snippet='MAX_FEE'
+      lang='py'
+      title='Set a maximum fee limit'
+      frame='none'
+    />   */}
+  </TabItem>
+</Tabs>
 
 ## Inner Transaction Fees
 
-[Inner transactions](FUTURELINK:link-to-inner-txn-page) are transactions sent by an [application account](FUTURELINK:link-to-app-account-page). When an account makes an application call transaction to a contract method with one inner transaction, there are two ways to cover the associated inner transaction fee.
+[Inner transactions](/concepts/smart-contracts/inner-txn) are transactions sent by an [application account](/concepts/smart-contracts/inner-txn). When an account makes an application call transaction to a contract method with one inner transaction, there are two ways to cover the associated inner transaction fee.
 
 - **App caller pays fees (recommended)**: The account calling the contract method pays for both the application call and the inner transaction fees through fee pooling. This approach is recommended because the inner transaction execution doesn't depend on the application account's ALGO balance.
 - **App account pays fees (not recommended)**: The application account itself pays the inner transaction fee using its own ALGO balance. This approach is discouraged because repeated calls to the method could deplete the application's ALGO balance, eventually resulting in "insufficient balance" errors that prevent the application from functioning.
 
 Smart Contract Inner transactions may have their fees covered by the outer transactions, but they cannot cover outer transaction fees. This limitation that only outer transactions may cover the inner transactions is true in the case of nested smart contract inner transactions as well. For example, if Smart Contract A is called, which then calls Smart Contract B, which then calls Smart Contract C, then C's fee can not cover the call for B, which can not cover the call to A.
+
+Refer to the [Inner Transactions](/concepts/smart-contracts/inner-txn#payment) page for code examples.
 
 ### Fee Structure
 
@@ -98,4 +162,31 @@ Inner transaction fees are **fixed at 1,000 microAlgo** per transaction, regardl
 
 Here is an example of calling a smart contract with an inner transaction and covering the inner transaction fee with the outer transaction.
 
-#code example
+This is the `payment` contract method that will be called and it has one inner payment transaction. 
+
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/smart_contracts/inner_transactions/contract.py'
+      snippet='PAYMENT'
+      lang='py'
+      title='Payment Inner Transaction'
+      frame='none'
+    />
+  </TabItem>
+</Tabs>
+
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript' icon='seti:typescript'>
+  </TabItem>
+  <TabItem label='Python' icon='seti:python'>
+    {/* <RemoteCode
+      src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
+      snippet='MAX_FEE'
+      lang='py'
+      title='Set a maximum fee limit'
+      frame='none'
+    />   */}
+  </TabItem>
+</Tabs>

--- a/src/content/docs/concepts/transactions/fees.mdx
+++ b/src/content/docs/concepts/transactions/fees.mdx
@@ -6,7 +6,7 @@ Blockchains like Algorand are decentralized networks with finite computational r
 
 ## Minimum Fee
 
-The minimum fee for each transaction on Algorand is 1000 microAlgo or 0.001 Algo, and it is **fixed** to this amount when the network is not congested. 
+The minimum fee for each transaction on Algorand is 1000 microAlgo or 0.001 Algo, and it is **fixed** to this amount when the network is not congested.
 
 ## Fee Calculation Formula
 
@@ -15,6 +15,7 @@ For a transaction that has been serialized into bytes (`txn_in_bytes`) and given
 ```shell showLineNumbers=false frame=none title="Fee Calculation"
 fee = max(current_fee_per_byte*len(txn_in_bytes), min_fee)
 ```
+
 If the network is not congested, the `current_fee_per_byte` will be zero, and the minimum transaction fee will be used.
 
 If the network is congested, the `current_fee_per_byte` will be non-zero. For a given transaction, if the product of the transaction's size in bytes and the current fee per byte is greater than the minimum fee, the product is used as the fee. Otherwise, the minimum fee is used.
@@ -22,11 +23,13 @@ If the network is congested, the `current_fee_per_byte` will be non-zero. For a 
 Transaction fees in Algorand apply uniformly across all transaction types—payments, Asset transfers, application calls, and others all use the same fee structure. Application call transaction fees also don't vary based on the complexity of the smart contract code being executed. Only the size of the serialized transaction determines the fee.
 
 ## Suggested Fee
+
 The [algod REST server](FUTURELINK: link to algod REST server page) provides `suggestedParams` that include the suggested `current fee per byte`. This suggested fee is used to determines transaction costs through this simple formula:
 
 ```shell showLineNumbers=false frame=none title="Fee Calculation"
 fee = max(current_fee_per_byte * transaction_size_in_bytes, min_fee)
 ```
+
 When the network isn't congested, `current_fee_per_byte` equals zero, simplifying the formula to:
 
 ```shell showLineNumbers=false frame=none title="Fee Calculation (Normal Network Conditions)"
@@ -42,15 +45,16 @@ When using suggested fees, always set a maximum fee limit. During network conges
 #code example
 
 ### Algorand Client Suggested Params Configuration
+
 The [Algorand Client](FUTURELINK:link_to_algorand_client_page) caches suggested parameters provided by the network automatically to reduce network traffic. It has a set of default configurations that control this behavior, but the default configuration can be overridden and changed:
+
 - `algorand.setDefaultValidityWindow(validityWindow)` - Set the default validity window (number of rounds from the current known round that the transaction will be valid to be accepted for). Having a smallish value for this is usually ideal to avoid transactions that are valid for a long future period and may be submitted even after you think it failed to submit if waiting for a particular number of rounds for the transaction to be successfully submitted. The validity window defaults to 10, except in automated testing where it's set to 1000 when targeting LocalNet.
 - `algorand.setSuggestedParams(suggestedParams, until?)` - Set the suggested network parameters to use (optionally until the given time)
 - `algorand.setSuggestedParamsTimeout(timeout)` - Set the timeout that is used to cache the suggested network parameters (by default 3 seconds)
 - `algorand.getSuggestedParams()` - Get the current suggested network parameters object, either the cached value, or if the cache has expired a fresh value
 
-
-
 ## Flat Fee
+
 The suggested parameters include a flat fee field that enables manual fee configuration. When set to true, you can specify exactly how much you want to pay for a transaction.
 
 If you choose this method, ensure your specified fee meets at least the minimum transaction fee (min-fee) available in the suggested parameters through the Algorand Client.
@@ -63,12 +67,13 @@ If you choose this method, ensure your specified fee meets at least the minimum 
 - Handling non-urgent transactions that can be retried if rejected
 
 ## Pooled transaction fees
+
 The Algorand protocol supports pooled fees, where one transaction can pay the fees of other transactions within the same [atomic group](FUTURELINK:link-to-atomic-group).
 
 For atomic transactions, the fees set on all transactions in the group are summed. This sum is compared against the protocol determined expected fee for the group and may proceed as long as the sum of the fees is greater than or equal to the required fee for the group.
 
 {/* ![Atomic Pooled Fees](../../imgs/atomic_transfers-2.png)
-*Atomic Pooled Fees* */}
+*Atomic Pooled Fees\* \*/}
 
 Below is an example of setting a pooled fee on an atomic group of two transactions. Here transaction B's fee is directly set to be 2x the minimum fee and transaction A's fee is set to zero. This atomic group will successfully execute because the sum of the fees is greater than or equal to the required fee for the group.
 
@@ -84,7 +89,9 @@ Below is an example of setting a pooled fee on an atomic group of two transactio
 Smart Contract Inner transactions may have their fees covered by the outer transactions, but they cannot cover outer transaction fees. This limitation that only outer transactions may cover the inner transactions is true in the case of nested smart contract inner transactions as well. For example, if Smart Contract A is called, which then calls Smart Contract B, which then calls Smart Contract C, then C's fee can not cover the call for B, which can not cover the call to A.
 
 ### Fee Structure
+
 Inner transaction fees are **fixed at 1,000 microAlgo** per transaction, regardless of network congestion. To properly cover fees:
+
 - For one inner transaction: Add 1,000 microALGO to the outer transaction fee
 - For two inner transactions: Add 2,000 microALGO to the outer transaction fee
 - And so on for additional inner transactions
@@ -92,6 +99,3 @@ Inner transaction fees are **fixed at 1,000 microAlgo** per transaction, regardl
 Here is an example of calling a smart contract with an inner transaction and covering the inner transaction fee with the outer transaction.
 
 #code example
-
-
-

--- a/src/content/docs/concepts/transactions/fees.mdx
+++ b/src/content/docs/concepts/transactions/fees.mdx
@@ -14,7 +14,9 @@ Blockchains like Algorand are decentralized networks with finite computational r
 The minimum fee for each transaction on Algorand is 1000 microAlgo or 0.001 Algo, and it is **fixed** to this amount when the network is not congested.
 
 ## Fee Calculation Formula
+
 The total fee of a transaction is calculated using the following formula where:
+
 - `txn_in_bytes` is the size of the transaction in bytes
 - `fee_per_byte` is the current network's congestion-based fee per byte
 - `min_fee` is the minimum fee for a transaction
@@ -48,8 +50,7 @@ This is why standard Algorand transactions cost **0.001 ALGO** or **1000 microAl
 Here is an example of how to get suggested parameters using the Algorand Client.
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript' icon='seti:typescript'>
-  </TabItem>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
   <TabItem label='Python' icon='seti:python'>
     {/* <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
@@ -60,7 +61,6 @@ Here is an example of how to get suggested parameters using the Algorand Client.
     />   */}
   </TabItem>
 </Tabs>
-
 
 ### Algorand Client Suggested Params Configuration
 
@@ -75,8 +75,7 @@ The [Algorand Client](FUTURELINK:link_to_algorand_client_page) caches suggested 
 When using suggested fees, always set a maximum fee limit. During network congestion, fees become variable and could increase significantly based on network conditions.
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript' icon='seti:typescript'>
-  </TabItem>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
   <TabItem label='Python' icon='seti:python'>
     {/* <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
@@ -103,8 +102,7 @@ If you choose this method, ensure your specified fee meets at least the minimum 
 - Handling non-urgent transactions that can be retried if rejected
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript' icon='seti:typescript'>
-  </TabItem>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
   <TabItem label='Python' icon='seti:python'>
     {/* <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
@@ -128,8 +126,7 @@ For atomic transactions, the fees set on all transactions in the group are summe
 Below is an example of setting a pooled fee on an atomic group of two transactions. Here transaction B's fee is directly set to be 2x the minimum fee and transaction A's fee is set to zero. This atomic group will successfully execute because the sum of the fees is greater than or equal to the required fee for the group.
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript' icon='seti:typescript'>
-  </TabItem>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
   <TabItem label='Python' icon='seti:python'>
     {/* <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      
@@ -162,7 +159,7 @@ Inner transaction fees are **fixed at 1,000 microAlgo** per transaction, regardl
 
 Here is an example of calling a smart contract with an inner transaction and covering the inner transaction fee with the outer transaction.
 
-This is the `payment` contract method that will be called and it has one inner payment transaction. 
+This is the `payment` contract method that will be called and it has one inner payment transaction.
 
 <Tabs syncKey='lang'>
   <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
@@ -178,8 +175,7 @@ This is the `payment` contract method that will be called and it has one inner p
 </Tabs>
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript' icon='seti:typescript'>
-  </TabItem>
+  <TabItem label='TypeScript' icon='seti:typescript'></TabItem>
   <TabItem label='Python' icon='seti:python'>
     {/* <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/algokit_utils_py_examples/assets(ASA)/asset_transfer.py'      

--- a/src/content/docs/concepts/transactions/fees.mdx
+++ b/src/content/docs/concepts/transactions/fees.mdx
@@ -1,0 +1,97 @@
+---
+title: Transaction Fees
+---
+
+Blockchains like Algorand are decentralized networks with finite computational resources. Transaction fees serve as an essential economic mechanism to protect the network by requiring users to pay for the computational resources their transactions use. This fee structure protects Algorand against potential spam attacks that could overwhelm the system and prevent the blockchain from being trapped in infinite computational loops that compromise performance and security.
+
+## Minimum Fee
+
+The minimum fee for each transaction on Algorand is 1000 microAlgo or 0.001 Algo, and it is **fixed** to this amount when the network is not congested. 
+
+## Fee Calculation Formula
+
+For a transaction that has been serialized into bytes (`txn_in_bytes`) and given the current network's congestion-based fee per byte (`fee_per_byte`), the total transaction fee is calculated using this formula:
+
+```shell showLineNumbers=false frame=none title="Fee Calculation"
+fee = max(current_fee_per_byte*len(txn_in_bytes), min_fee)
+```
+If the network is not congested, the `current_fee_per_byte` will be zero, and the minimum transaction fee will be used.
+
+If the network is congested, the `current_fee_per_byte` will be non-zero. For a given transaction, if the product of the transaction's size in bytes and the current fee per byte is greater than the minimum fee, the product is used as the fee. Otherwise, the minimum fee is used.
+
+Transaction fees in Algorand apply uniformly across all transaction types—payments, Asset transfers, application calls, and others all use the same fee structure. Application call transaction fees also don't vary based on the complexity of the smart contract code being executed. Only the size of the serialized transaction determines the fee.
+
+## Suggested Fee
+The [algod REST server](FUTURELINK: link to algod REST server page) provides `suggestedParams` that include the suggested `current fee per byte`. This suggested fee is used to determines transaction costs through this simple formula:
+
+```shell showLineNumbers=false frame=none title="Fee Calculation"
+fee = max(current_fee_per_byte * transaction_size_in_bytes, min_fee)
+```
+When the network isn't congested, `current_fee_per_byte` equals zero, simplifying the formula to:
+
+```shell showLineNumbers=false frame=none title="Fee Calculation (Normal Network Conditions)"
+fee = max(0, min_fee) = min_fee
+```
+
+This is why standard Algorand transactions cost **0.001 ALGO** or **1000 microAlgo** during normal network conditions.
+
+:::note
+When using suggested fees, always set a maximum fee limit. During network congestion, fees become variable and could increase significantly based on network conditions.
+:::
+
+#code example
+
+### Algorand Client Suggested Params Configuration
+The [Algorand Client](FUTURELINK:link_to_algorand_client_page) caches suggested parameters provided by the network automatically to reduce network traffic. It has a set of default configurations that control this behavior, but the default configuration can be overridden and changed:
+- `algorand.setDefaultValidityWindow(validityWindow)` - Set the default validity window (number of rounds from the current known round that the transaction will be valid to be accepted for). Having a smallish value for this is usually ideal to avoid transactions that are valid for a long future period and may be submitted even after you think it failed to submit if waiting for a particular number of rounds for the transaction to be successfully submitted. The validity window defaults to 10, except in automated testing where it's set to 1000 when targeting LocalNet.
+- `algorand.setSuggestedParams(suggestedParams, until?)` - Set the suggested network parameters to use (optionally until the given time)
+- `algorand.setSuggestedParamsTimeout(timeout)` - Set the timeout that is used to cache the suggested network parameters (by default 3 seconds)
+- `algorand.getSuggestedParams()` - Get the current suggested network parameters object, either the cached value, or if the cache has expired a fresh value
+
+
+
+## Flat Fee
+The suggested parameters include a flat fee field that enables manual fee configuration. When set to true, you can specify exactly how much you want to pay for a transaction.
+
+If you choose this method, ensure your specified fee meets at least the minimum transaction fee (min-fee) available in the suggested parameters through the Algorand Client.
+
+### Use Cases for Flat Fees
+
+- Covering extra fees in transaction groups or app calls with inner transactions
+- Displaying specific rounded fees to users in applications
+- Preparing future transactions when network conditions are unknown
+- Handling non-urgent transactions that can be retried if rejected
+
+## Pooled transaction fees
+The Algorand protocol supports pooled fees, where one transaction can pay the fees of other transactions within the same [atomic group](FUTURELINK:link-to-atomic-group).
+
+For atomic transactions, the fees set on all transactions in the group are summed. This sum is compared against the protocol determined expected fee for the group and may proceed as long as the sum of the fees is greater than or equal to the required fee for the group.
+
+{/* ![Atomic Pooled Fees](../../imgs/atomic_transfers-2.png)
+*Atomic Pooled Fees* */}
+
+Below is an example of setting a pooled fee on an atomic group of two transactions. Here transaction B's fee is directly set to be 2x the minimum fee and transaction A's fee is set to zero. This atomic group will successfully execute because the sum of the fees is greater than or equal to the required fee for the group.
+
+#code example
+
+## Inner Transaction Fees
+
+[Inner transactions](FUTURELINK:link-to-inner-txn-page) are transactions sent by an [application account](FUTURELINK:link-to-app-account-page). When an account makes an application call transaction to a contract method with one inner transaction, there are two ways to cover the associated inner transaction fee.
+
+- **App caller pays fees (recommended)**: The account calling the contract method pays for both the application call and the inner transaction fees through fee pooling. This approach is recommended because the inner transaction execution doesn't depend on the application account's ALGO balance.
+- **App account pays fees (not recommended)**: The application account itself pays the inner transaction fee using its own ALGO balance. This approach is discouraged because repeated calls to the method could deplete the application's ALGO balance, eventually resulting in "insufficient balance" errors that prevent the application from functioning.
+
+Smart Contract Inner transactions may have their fees covered by the outer transactions, but they cannot cover outer transaction fees. This limitation that only outer transactions may cover the inner transactions is true in the case of nested smart contract inner transactions as well. For example, if Smart Contract A is called, which then calls Smart Contract B, which then calls Smart Contract C, then C's fee can not cover the call for B, which can not cover the call to A.
+
+### Fee Structure
+Inner transaction fees are **fixed at 1,000 microAlgo** per transaction, regardless of network congestion. To properly cover fees:
+- For one inner transaction: Add 1,000 microALGO to the outer transaction fee
+- For two inner transactions: Add 2,000 microALGO to the outer transaction fee
+- And so on for additional inner transactions
+
+Here is an example of calling a smart contract with an inner transaction and covering the inner transaction fee with the outer transaction.
+
+#code example
+
+
+

--- a/src/content/docs/reference/rest-api/overview.md
+++ b/src/content/docs/reference/rest-api/overview.md
@@ -24,9 +24,21 @@ Algorand provides endpoints for [Open API Specification version 2 (OAS2)](https:
 
 [Algod REST Endpoints OAS2 spec file](https://github.com/algorand/go-algorand/blob/master/daemon/algod/api/algod.oas2.json?raw=true)
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/35060167-e2f8f2e0-807f-4d5e-a153-23231ef25316?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-e2f8f2e0-807f-4d5e-a153-23231ef25316%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76)
+<a href="https://algorand-algod.apidocumentation.com/reference" style="display: inline-block;">
+  <img src="https://img.shields.io/badge/Run%20in-Scalar-4A90E2?style=flat&logoColor=4A90E2&color=f0f0f0" alt="Run in Scalar">
+</a>
 
-[![Run in Swagger](https://img.shields.io/badge/Run%20in-Swagger-85EA2D?logo=swagger&logoColor=black)](https://nodely.io/swagger/index.html?url=/swagger/api/4160/algod.oas3.yml)
+<br>
+
+<a href="https://nodely.io/swagger/index.html?url=/swagger/api/4160/algod.oas3.yml" style="display: inline-block;">
+  <img src="https://img.shields.io/badge/Run%20in-Swagger-85EA2D?logo=swagger&logoColor=black" alt="Run in Swagger">
+</a>
+
+<br>
+
+<a href="https://god.gw.postman.com/run-collection/35060167-e2f8f2e0-807f-4d5e-a153-23231ef25316?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-e2f8f2e0-807f-4d5e-a153-23231ef25316%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76" style="display: inline-block; margin-bottom: 10px;">
+  <img src="https://run.pstmn.io/button.svg" alt="Run in Postman">
+</a>
 
 ### Indexer REST Endpoints
 
@@ -36,9 +48,21 @@ The `algorand-indexer` daemon provides its API from the _host:port_ defined by t
 
 [Indexer REST Endpoints OAS2 spec file](https://github.com/algorand/indexer/blob/develop/api/indexer.oas2.json?raw=true)
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/35060167-51480ac3-c621-4c2d-a5e1-5c763fa976a3?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-51480ac3-c621-4c2d-a5e1-5c763fa976a3%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76)
+<a href="https://algorand-indexer.apidocumentation.com/reference" style="display: inline-block;">
+  <img src="https://img.shields.io/badge/Run%20in-Scalar-4A90E2?style=flat&logoColor=4A90E2&color=f0f0f0" alt="Run in Scalar">
+</a>
 
-[![Run in Swagger](https://img.shields.io/badge/Run%20in-Swagger-85EA2D?logo=swagger&logoColor=black)](https://nodely.io/swagger/index.html?url=/swagger/api/4160/indexer.oas3.yml)
+<br>
+
+<a href="https://nodely.io/swagger/index.html?url=/swagger/api/4160/indexer.oas3.yml" style="display: inline-block;">
+  <img src="https://img.shields.io/badge/Run%20in-Swagger-85EA2D?logo=swagger&logoColor=black" alt="Run in Swagger">
+</a>
+
+<br>
+
+<a href="https://god.gw.postman.com/run-collection/35060167-51480ac3-c621-4c2d-a5e1-5c763fa976a3?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-51480ac3-c621-4c2d-a5e1-5c763fa976a3%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76" style="display: inline-block; margin-bottom: 10px;">
+  <img src="https://run.pstmn.io/button.svg" alt="Run in Postman">
+</a>
 
 ### KMD REST Endpoints
 
@@ -54,7 +78,9 @@ Algorand Key Management Daemon (`kmd`)
 curl http://$(cat ~/node/data/kmd-v0.5/kmd.net)/swagger.json
 ```
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/35060167-0823a4c5-1a2f-499a-9e24-6b6639a057ef?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-0823a4c5-1a2f-499a-9e24-6b6639a057ef%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76)
+<a href="https://god.gw.postman.com/run-collection/35060167-0823a4c5-1a2f-499a-9e24-6b6639a057ef?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D35060167-0823a4c5-1a2f-499a-9e24-6b6639a057ef%26entityType%3Dcollection%26workspaceId%3D19492cc5-4dbb-46fc-9845-c45db4333e76" style="display: inline-block;">
+  <img src="https://run.pstmn.io/button.svg" alt="Run in Postman">
+</a>
 
 :::note
 The `kmd` daemon is only automatically started when using the `goal` command line tool with specific commands requiring key management access. If you require API access to `kmd` you will need to manually start the process with `goal` using the command: `goal kmd start -d <data-dir>`. If the kmd is started with the above command it never times out and stops running unless a timeout flag is specified with the -t flag. The default of 0 is no timeout.


### PR DESCRIPTION
# ℹ Overview

- Added "Run with Scalar" to the overview page
- Run with X buttons are no longer clickable full width
- applied sorting the sidebar alphabetically using operation ids

### ✅ Acceptance:
- [X] Lint passes