### PR TITLE
Fixed media type for landing page animation

### DIFF
--- a/src/components/homepage/HomepageHero.astro
+++ b/src/components/homepage/HomepageHero.astro
@@ -23,7 +23,7 @@ const heroData = {
   >
     <div class='lg:min-w-[64%]'>
       <video muted autoplay loop class='dark:hidden mt-0! w-full h-auto'>
-        <source src={LaptopLightClip} type='video/mp4' />
+        <source src={LaptopLightClip} type='video/webm' />
       </video>
       <video
         muted


### PR DESCRIPTION
# ℹ Overview

Landing page animation was not displaying correctly on mobile. This was due to a mismatched media type in the `<video>` element.

### 📝 Related Issues

<!--
- resolves #1
-->

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [X] Lint passes