### PR TITLE
fix: algokit CLI docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1084,16 +1084,6 @@ export default defineConfig({
           collapsed: true,
           items: [
             {
-              label: 'AlgoKit CLI',
-              collapsed: true,
-              items: [
-                {
-                  label: 'Algokit CLI Reference',
-                  link: 'reference/algokit-cli/cli-reference',
-                },
-              ],
-            },
-            {
               label: 'Algorand Python',
               collapsed: true,
               items: [

--- a/imports/scripts/algokit-cli.ts
+++ b/imports/scripts/algokit-cli.ts
@@ -34,17 +34,6 @@ await processDirectories([
 ]);
 await processFile([
     {
-        src: scriptLocation + '/../repos/algokit-cli/docs/cli/index.md',
-        transformations: [
-            convertH1ToFrontmatter,
-            stripLinkExtensions,
-            changeFeatureLinks,
-            changeReferenceLinks,
-            removeToc,
-        ],
-        dest: scriptLocation + '/../../src/content/docs/reference/algokit-cli/reference.md'
-    },
-    {
         src: scriptLocation + '/../repos/algokit-cli/docs/algokit.md',
         transformations: [
             convertH1ToFrontmatter,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "astro dev",
     "predev": "pnpm run generate-diagrams && pnpm run generate-openapi-docs",
     "prebuild": "pnpm run generate-diagrams && pnpm run generate-openapi-docs",
-    "build": "pnpm run import:all && astro check && astro build",
+    "build": "pnpm run import && astro check && astro build",
     "lint:fix": "eslint . && prettier -c ./src/** --write && astro check",
     "lint": "eslint . && prettier -c ./src/** && astro check",
     "preview": "astro preview",
@@ -15,14 +15,14 @@
     "generate-diagrams": "npx tsx scripts/generate-diagrams.ts",
     "generate-openapi-docs": "npx tsx scripts/generate-openapi-docs.js",
     "init:submodules": "git submodule update --init",
-    "import:all": "pnpm run init:submodules && pnpm run import:nodekit",
     "import:nodekit": "npx tsx imports/scripts/nodekit.ts && prettier --write src/content/docs/nodes/nodekit-reference/",
-    "init:poetry": "cd imports/build/python && poetry install",
+    "import:poetry": "cd imports/build/python && poetry install",
     "import:utils-ts": "cd imports/repos/algokit-utils-ts && npm install",
     "import:algorand-python": "cd imports/build/python && make puya",
     "import:utils-py": "cd imports/build/python && make utils",
     "import:algorand-typescript": "cd imports/repos/puya-ts && npm install",
-    "import": "pnpm run init:poetry && pnpm run init:submodules && pnpm run import:utils-ts && pnpm run import:algorand-python && pnpm run import:utils-py"
+    "import:algokit-cli": "tsx imports/scripts/algokit-cli.ts && prettier --write src/content/docs/algokit/algokit-cli",
+    "import": "pnpm run init:submodules && pnpm run import:nodekit && pnpm run import:poetry && pnpm run import:utils-ts && pnpm run import:algorand-python && pnpm run import:utils-py && pnpm run import:algorand-typescript && pnpm run import:algokit-cli"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/content/docs/algokit/algokit-cli/dispenser.md
+++ b/src/content/docs/algokit/algokit-cli/dispenser.md
@@ -86,3 +86,7 @@ This command gets information about current fund limits on your account. The lim
 Options
 
 - `--whole-units`: Use whole units (Algos) instead of smallest divisible units (microAlgos). Disabled by default.
+
+## Further Reading
+
+For in-depth details, visit the [dispenser section](../cli/index#dispenser) in the AlgoKit CLI reference documentation.

--- a/src/content/docs/algokit/algokit-cli/doctor.md
+++ b/src/content/docs/algokit/algokit-cli/doctor.md
@@ -10,6 +10,8 @@ The AlgoKit Doctor allows you to make sure that your system has the correct depe
 
 Please run this command to if you are facing an issue running AlgoKit. It is recommended to run it before [submitting an issue to AlgoKit](https://github.com/algorandfoundation/algokit-cli/issues/new). You can copy the contents of the Doctor command message (in Markdown format) to your clipboard by providing the `-c` flag to the command as follows `algokit doctor -c`.
 
+> NOTE: You can also use the `--verbose` or `-v` flag to show additional information including package dependencies of the AlgoKit CLI: `algokit -v doctor`. This only works when `algokit` is installed as a Python package (e.g., via `pipx install algokit`).
+
 # Examples
 
 For example, running `algokit doctor` with all prerequisites installed will result in output similar to the following:

--- a/src/content/docs/reference/rest-api/algod.md
+++ b/src/content/docs/reference/rest-api/algod.md
@@ -2562,7 +2562,8 @@ Given a specific account public key and application ID, this call returns the ac
     "local-state-schema": {
       "num-byte-slice": 0,
       "num-uint": 0
-    }
+    },
+    "version": 0
   },
   "round": 0
 }
@@ -2603,6 +2604,7 @@ Status Code **200**
 |»» global-state|[[TealKeyValue](#schematealkeyvalue)]|false|none|Represents a key-value store for use in an application.|
 |»» global-state-schema|[ApplicationStateSchema](#schemaapplicationstateschema)|false|none|Specifies maximums on the number of each type that may be stored.|
 |»» local-state-schema|[ApplicationStateSchema](#schemaapplicationstateschema)|false|none|Specifies maximums on the number of each type that may be stored.|
+|»» version|integer|false|none|\[v\] the number of updates to the application programs|
 |» round|integer|true|none|The round for which this information is relevant.|
 
 <aside class="warning">
@@ -3335,7 +3337,8 @@ Given a specific account public key, this call returns the account's status, bal
         "local-state-schema": {
           "num-byte-slice": 0,
           "num-uint": 0
-        }
+        },
+        "version": 0
       }
     }
   ],
@@ -4160,7 +4163,8 @@ Given a application ID, it returns application information including creator, ap
     "local-state-schema": {
       "num-byte-slice": 0,
       "num-uint": 0
-    }
+    },
+    "version": 0
   }
 }
 ```
@@ -5525,14 +5529,39 @@ Returns the entire genesis file in json.
 > 200 Response
 
 ```json
-"string"
+{
+  "alloc": [
+    {
+      "addr": "string",
+      "comment": "string",
+      "state": {
+        "algo": 0,
+        "onl": 0,
+        "sel": "string",
+        "stprf": "string",
+        "vote": "string",
+        "voteFst": 0,
+        "voteKD": 0,
+        "voteLst": 0
+      }
+    }
+  ],
+  "comment": "string",
+  "devmode": true,
+  "fees": "string",
+  "id": "string",
+  "network": "string",
+  "proto": "string",
+  "rwd": "string",
+  "timestamp": 0
+}
 ```
 
 #### Responses
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The genesis file in json.|string|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|The genesis file in json.|[Genesis](#schemagenesis)|
 |default|Default|Unknown Error|None|
 
 #### Response Schema
@@ -10820,7 +10849,8 @@ const inputBody = '{
             "local-state-schema": {
               "num-byte-slice": 0,
               "num-uint": 0
-            }
+            },
+            "version": 0
           }
         }
       ],
@@ -10897,7 +10927,8 @@ const inputBody = '{
         "local-state-schema": {
           "num-byte-slice": 0,
           "num-uint": 0
-        }
+        },
+        "version": 0
       }
     }
   ],
@@ -11117,7 +11148,8 @@ Executes TEAL program(s) in context and returns debugging information about the 
             "local-state-schema": {
               "num-byte-slice": 0,
               "num-uint": 0
-            }
+            },
+            "version": 0
           }
         }
       ],
@@ -11194,7 +11226,8 @@ Executes TEAL program(s) in context and returns debugging information about the 
         "local-state-schema": {
           "num-byte-slice": 0,
           "num-uint": 0
-        }
+        },
+        "version": 0
       }
     }
   ],
@@ -12072,7 +12105,8 @@ api_key
         "local-state-schema": {
           "num-byte-slice": 0,
           "num-uint": 0
-        }
+        },
+        "version": 0
       }
     }
   ],
@@ -12345,7 +12379,8 @@ The logged messages from an app call along with the app ID and outer transaction
     "local-state-schema": {
       "num-byte-slice": 0,
       "num-uint": 0
-    }
+    },
+    "version": 0
   }
 }
 
@@ -12556,7 +12591,8 @@ Stores local state associated with an application.
   "local-state-schema": {
     "num-byte-slice": 0,
     "num-uint": 0
-  }
+  },
+  "version": 0
 }
 
 ```
@@ -12574,6 +12610,7 @@ Stores the global information associated with an application.
 |global-state|[TealKeyValueStore](#schematealkeyvaluestore)|false|none|Represents a key-value store for use in an application.|
 |global-state-schema|[ApplicationStateSchema](#schemaapplicationstateschema)|false|none|Specifies maximums on the number of each type that may be stored.|
 |local-state-schema|[ApplicationStateSchema](#schemaapplicationstateschema)|false|none|Specifies maximums on the number of each type that may be stored.|
+|version|integer|false|none|\[v\] the number of updates to the application programs|
 
 
 ### ApplicationStateOperation
@@ -13025,7 +13062,8 @@ algod mutex and blocking profiling state.
             "local-state-schema": {
               "num-byte-slice": 0,
               "num-uint": 0
-            }
+            },
+            "version": 0
           }
         }
       ],
@@ -13102,7 +13140,8 @@ algod mutex and blocking profiling state.
         "local-state-schema": {
           "num-byte-slice": 0,
           "num-uint": 0
-        }
+        },
+        "version": 0
       }
     }
   ],
@@ -13406,6 +13445,104 @@ Key-value pairs for StateDelta.
 |---|---|---|---|---|
 |key|string|true|none|none|
 |value|[EvalDelta](#schemaevaldelta)|true|none|Represents a TEAL value delta.|
+
+
+### Genesis
+<!-- backwards compatibility -->
+<a id="schemagenesis"></a>
+<a id="schema_Genesis"></a>
+<a id="tocSgenesis"></a>
+<a id="tocsgenesis"></a>
+
+```json
+{
+  "alloc": [
+    {
+      "addr": "string",
+      "comment": "string",
+      "state": {
+        "algo": 0,
+        "onl": 0,
+        "sel": "string",
+        "stprf": "string",
+        "vote": "string",
+        "voteFst": 0,
+        "voteKD": 0,
+        "voteLst": 0
+      }
+    }
+  ],
+  "comment": "string",
+  "devmode": true,
+  "fees": "string",
+  "id": "string",
+  "network": "string",
+  "proto": "string",
+  "rwd": "string",
+  "timestamp": 0
+}
+
+```
+
+Genesis File in JSON
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|alloc|[[GenesisAllocation](#schemagenesisallocation)]|true|none|none|
+|comment|string|false|none|none|
+|devmode|boolean|false|none|none|
+|fees|string|true|none|none|
+|id|string|true|none|none|
+|network|string|true|none|none|
+|proto|string|true|none|none|
+|rwd|string|true|none|none|
+|timestamp|integer(int64)|true|none|none|
+
+
+### GenesisAllocation
+<!-- backwards compatibility -->
+<a id="schemagenesisallocation"></a>
+<a id="schema_GenesisAllocation"></a>
+<a id="tocSgenesisallocation"></a>
+<a id="tocsgenesisallocation"></a>
+
+```json
+{
+  "addr": "string",
+  "comment": "string",
+  "state": {
+    "algo": 0,
+    "onl": 0,
+    "sel": "string",
+    "stprf": "string",
+    "vote": "string",
+    "voteFst": 0,
+    "voteKD": 0,
+    "voteLst": 0
+  }
+}
+
+```
+
+Allocations for Genesis File
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|addr|string|true|none|none|
+|comment|string|true|none|none|
+|state|object|true|none|none|
+|» algo|integer(uint64)|true|none|none|
+|» onl|integer|false|none|none|
+|» sel|string|false|none|none|
+|» stprf|string|false|none|none|
+|» vote|string|false|none|none|
+|» voteFst|integer(uint64)|false|none|none|
+|» voteKD|integer(uint64)|false|none|none|
+|» voteLst|integer(uint64)|false|none|none|
 
 
 ### LedgerStateDelta


### PR DESCRIPTION
This PR addresses two things:

1. The package.json scripts were a bit wonky. Primarily I needed to add the missing `algokit-cli` and consolidate `import` and `import:all`. 
2. algokit-cli script was generating empty reference docs. I assume we just don't want CLI under reference?

Also, the algokit-cli submodule was out of date. It seems like someone changed the submodule, generated docs, but didn't commit the submodule.