### PR TITLE
Add Protocol Parameters page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -372,6 +372,10 @@ export default defineConfig({
                   link: 'concepts/protocol/overview',
                 },
                 {
+                  label: 'Protocol Parameters',
+                  link: 'concepts/protocol/protocol-parameters',
+                },
+                {
                   label: 'Participation Key Management',
                   link: 'concepts/protocol/partkey-management',
                 },

--- a/src/content/docs/concepts/accounts/overview.mdx
+++ b/src/content/docs/concepts/accounts/overview.mdx
@@ -47,7 +47,7 @@ Every account on Algorand must have a minimum balance of 100,000 microAlgos. If 
 
 <LinkCard
   title='Costs and Constraints'
-  href='/concepts/smart-contracts/costs-constraints'
+  href='/concepts/protocol/protocol-parameters'
   description='More about assets, applications, and changes to the minimum balance requirement'
 />
 

--- a/src/content/docs/concepts/protocol/protocol-parameters.mdx
+++ b/src/content/docs/concepts/protocol/protocol-parameters.mdx
@@ -1,0 +1,96 @@
+---
+title: Protocol Parameters
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+Protocol parameters are constants that define the limits and requirements of the Algorand blockchain. These parameters control various aspects of the network including transaction fees, minimum balances, smart contract constraints, and asset creation limits. Understanding these parameters is essential for developers building on Algorand, as they directly impact the cost and feasibility of different operations on the network.
+
+<LinkCard
+  title='Smart Contract Costs & Constraints'
+  description='Learn about the specific costs and constraints that affect smart contract development'
+  href='/concepts/smart-contracts/costs-constraints'
+/>
+
+## Minimum Balance Requirements
+
+| Parameter   | Value      | Variable   | Note                                  |
+| ----------- | ---------- | ---------- | ------------------------------------- |
+| Default     | 0.1 Algo   | MinBalance |                                       |
+| Opt-in ASA  | + 0.1 Algo | MinBalance |                                       |
+| Created ASA | + 0.1 Algo | MinBalance | ASA creator is automatically opted in |
+
+## Minimum Balance Requirements for Smart Contracts
+
+| Name                              | Value       | Variable                 | Note                           |
+| --------------------------------- | ----------- | ------------------------ | ------------------------------ |
+| Per page application creation fee | 0.1 Algo    | AppFlatParamsMinBalance  |                                |
+| Flat for application opt-in       | 0.1 Algo    | AppFlatOptInMinBalance   |                                |
+| Per state entry                   | 0.025 Algo  | SchemaMinBalancePerEntry |                                |
+| Addition per integer entry        | 0.0035 Algo | SchemaUintMinBalance     |                                |
+| Addition per byte slice entry     | 0.025 Algo  | SchemaBytesMinBalance    |                                |
+| Per Box created                   | 0.0025 Algo | BoxFlatMinBalance        |                                |
+| Per byte in box created           | 0.0004 Algo | BoxByteMinBalance        | Includes the length of the key |
+
+## Transaction Parameters
+
+| Name                                       | Value                   | Variable             | Note                                                                                                                |
+| ------------------------------------------ | ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Minimum transaction fee, in all cases      | 0.001 Algo              | MinTxnFee            |                                                                                                                     |
+| Additional minimum constraint if congested | Additional fee per byte | -                    |                                                                                                                     |
+| Max number of transactions in a group      | 16                      | MaxTxGroupSize       |                                                                                                                     |
+| Max number of inner transactions           | 256                     | MaxInnerTransactions | Each transaction allows 16 inner transactions, multiplied by MaxTxGroupSize (16) through inner transaction pooling. |
+| Maximum size of a block                    | 5000000 bytes           | MaxTxnBytesPerBlock  |                                                                                                                     |
+| Maximum size of note                       | 1024 bytes              | MaxTxnNoteBytes      |                                                                                                                     |
+| Maximum transaction life                   | 1000 rounds             | MaxTxnLife           |                                                                                                                     |
+
+## ASA Parameters
+
+| Name                                   | Value     | Variable              | Note                                       |
+| -------------------------------------- | --------- | --------------------- | ------------------------------------------ |
+| Max number of ASAs (create and opt-in) | Unlimited | MaxAssetsPerAccount   |                                            |
+| Max asset name size                    | 32 bytes  | MaxAssetNameBytes     |                                            |
+| Max unit name size                     | 8 bytes   | MaxAssetUnitNameBytes |                                            |
+| Max URL size                           | 96 bytes  | MaxAssetURLBytes      |                                            |
+| Metadata hash                          | 32 bytes  |                       | Padded with zeros if shorter than 32 bytes |
+
+## Smart Signature Parameters
+
+| Name                                                   | Value      | Variable        | Note |
+| ------------------------------------------------------ | ---------- | --------------- | ---- |
+| Max size of compiled TEAL code combined with arguments | 1000 bytes | LogicSigMaxSize |      |
+| Max cost of TEAL code                                  | 20000      | LogicSigMaxCost |      |
+
+## Smart Contract Parameters
+
+| Name                                                               | Value      | Variable                 | Note                                                              |
+| ------------------------------------------------------------------ | ---------- | ------------------------ | ----------------------------------------------------------------- |
+| Page size of compiled approval + clear TEAL code                   | 2048 bytes | MaxAppProgramLen         | by default, each application has a single page                    |
+| Max extra app pages                                                | 3          | MaxExtraAppProgramPages  | an application can "pay" for additional pages via minimum balance |
+| Max cost of approval TEAL code                                     | 700        | MaxAppProgramCost        |                                                                   |
+| Max cost of clear TEAL code                                        | 700        | MaxAppProgramCost        |                                                                   |
+| Max number of scratch variables                                    | 256        |                          |                                                                   |
+| Max depth of stack                                                 | 1000       | MaxStackDepth            |                                                                   |
+| Max number of arguments                                            | 16         | MaxAppArgs               |                                                                   |
+| Max combined size of arguments                                     | 2048 bytes | MaxAppTotalArgLen        |                                                                   |
+| Max number of global state keys                                    | 64         | MaxGlobalSchemaEntries   |                                                                   |
+| Max number of local state keys                                     | 16         | MaxLocalSchemaEntries    |                                                                   |
+| Max number of log messages                                         | 32         | MaxLogCalls              |                                                                   |
+| Max size of log messages                                           | 1024       | MaxLogSize               |                                                                   |
+| Max key size                                                       | 64 bytes   | MaxAppKeyLen             |                                                                   |
+| Max []byte value size                                              | 128 bytes  | MaxAppBytesValueLen      |                                                                   |
+| Max key + value size                                               | 128 bytes  | MaxAppSumKeyValueLens    |                                                                   |
+| Max number of foreign accounts                                     | 4          | MaxAppTxnAccounts        |                                                                   |
+| Max number of foreign ASAs                                         | 8          | MaxAppTxnForeignAssets   |                                                                   |
+| Max number of foreign applications                                 | 8          | MaxAppTxnForeignApps     |                                                                   |
+| Max number of foreign accounts + ASAs + applications + box storage | 8          | MaxAppTotalTxnReferences |                                                                   |
+| Max number of created applications                                 | Unlimited  | MaxAppsCreated           |                                                                   |
+| Max number of opt-in applications                                  | Unlimited  | MaxAppsOptedIn           |                                                                   |
+
+## Box Parameters
+
+| Name                    | Value | Variable             | Note                                                             |
+| ----------------------- | ----- | -------------------- | ---------------------------------------------------------------- |
+| Max size of box         | 32768 | MaxBoxSize           | Does not include name/key length. That is capped by MaxAppKeyLen |
+| Max box references      | 8     | MaxAppBoxReferences  |                                                                  |
+| Bytes per Box reference | 1024  | BytesPerBoxReference |                                                                  |

--- a/src/content/docs/concepts/smart-contracts/costs-constraints.mdx
+++ b/src/content/docs/concepts/smart-contracts/costs-constraints.mdx
@@ -1,35 +1,22 @@
 ---
-title: Costs & Constraints
+title: Smart Contract Costs & Constraints
 ---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+This page covers the costs and constraints specific to smart contract development on Algorand. For a complete list of all protocol parameters including transaction fees, minimum balances, and other network-wide settings, see the main protocol parameters page.
+
+<LinkCard
+  title='Protocol Parameters'
+  description='Complete list of all Algorand protocol parameters including transaction fees, minimum balances, and network-wide constants'
+  href='/concepts/protocol/protocol-parameters'
+/>
 
 import { Image } from 'astro:assets';
 import Figure from '/src/components/Figure.astro';
 import mbr1 from '@images/smart-contract-mbr-1.png';
 import mbr2 from '@images/smart-contract-mbr-1.png';
 import mbr3 from '@images/smart-contract-mbr-1.png';
-
-## MBR
-
-The Minimum Balance Requirement (MBR) in Algorand refers to the minimum amount of Algos that an account must hold. This requirement is affected by various factors such as the creation or ownership of Algorand Standard Assets (ASAs), opting into or out of applications, and the storage of additional data.
-
-| Type            | Minimum Balance        | Description                                                                                                   |
-| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| Basic Account   | 0.1 Algo               | If ever a transaction is sent that will result in a balance lower than the minimum; the transaction will fail |
-| Opting into ASA | +0.1 Algo              | Increases: Opting into assets or applications, storing additional data (e.g., boxes in smart contracts)       |
-| Opting out ASA  | -0.1 Algo              | Decreases: Opting out of assets or applications, removing stored data                                         |
-| Smart Contracts | 0.1 Algo upon creation | Additional Increases: Based on state schema and number of extra program pages                                 |
-
-For eg. for a basic account the minimum balance requirement is 0.1 Algo
-
-<Figure src={mbr1} alt='MBR for Basic Account #1' width='600' />
-
-Now if this account creates an asset like below:
-
-<Figure src={mbr2} alt='MBR for Basic Account #2' width='600' />
-
-The min balance of the account increases by 0.1 Algos and now the minimum balance is 0.2 Algos
-
-<Figure src={mbr3} alt='MBR for Basic Account #3' width='600' />
 
 ## Program Constraints
 
@@ -92,27 +79,6 @@ In Algorand, the access and usage of resources such as account balance/state, ap
 | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Access Restrictions       | Limited access to resources like account balance and application state to ensure efficient block evaluation. |
 | Specification Requirement | Resources must be specified within the transaction for nodes to pre-fetch data.                              |
-
-### Transaction Fees
-
-| Attribute         | Details                                                       |
-| ----------------- | ------------------------------------------------------------- |
-| Minimum Fee       | 0.001 Algo per transaction, regardless of type.               |
-| Payment Condition | Fees are only paid if the transaction is included in a block. |
-
-### Smart Contract Constraints
-
-| Constraint Type        | Details                                                                                                           |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Opt-In Applications    | No limit on the number of applications an account can opt into.                                                   |
-| Size and Opcode Limits | Must adhere to program size and opcode budget constraints outlined in Program Constraints and Opcode Constraints. |
-
-### ASA Constraints
-
-| Constraint Type | Details                                                                           |
-| --------------- | --------------------------------------------------------------------------------- |
-| Quantity        | Unlimited number of Algorand Standard Assets (ASAs).                              |
-| Size Limits     | Asset Name: 32 bytes, Unit Name: 8 bytes, URL: 96 bytes, Metadata Hash: 32 bytes. |
 
 ### Access Constraints
 


### PR DESCRIPTION
# ℹ Overview

This PR mainly ports over the [parameter tables](https://developer.algorand.org/docs/get-details/parameter_tables/) page from the old docs, which includes a reference for all of the most common network parameters. I put it under Concepts > Consensus Protocol in the sidebar and named it Protocol Parameters. 

Additionally, I removed the information from the [Smart Contracts Costs & Constraints](https://dev.algorand.co/concepts/smart-contracts/costs-constraints/) page that is not related to smart contracts, and referred back to the new Protocol Parameters page.