### PR TITLE
Removed TOC; fixed filter issue

### DIFF
--- a/scripts/generate-opcode-list.js
+++ b/scripts/generate-opcode-list.js
@@ -98,6 +98,7 @@ async function main() {
 
   const template = Handlebars.compile(tplSrc, { noEscape: true });
   const opcodes = JSON.parse(dataSrc);
+  opcodes.sort((a, b) => a.Name.localeCompare(b.Name));
 
   const page = template({ opcodes });
 

--- a/src/components/OpcodeFilters.astro
+++ b/src/components/OpcodeFilters.astro
@@ -59,9 +59,9 @@
         grpSel.append(o);
       });
 
-    function previousH2(el) {
+    function previousH3(el) {
       let n = el.previousElementSibling;
-      while (n && n.tagName !== 'H2') n = n.previousElementSibling;
+      while (n && n.tagName !== 'H3') n = n.previousElementSibling;
       return n || null;
     }
 
@@ -82,7 +82,7 @@
         sec.hidden = !show;
 
         // toggle the heading just before the container
-        const h2 = previousH2(sec);
+        const h2 = previousH3(sec);
         if (h2) h2.hidden = !show;
       }
     }

--- a/templates/opcodes.md.hbs
+++ b/templates/opcodes.md.hbs
@@ -1,8 +1,6 @@
 ---
 title: AVM Opcodes
-tableOfContents:
-  minHeadingLevel: 3
-  maxHeadingLevel: 3
+tableOfContents: false
 ---
 
 import OpcodeFilters from "../../../../components/OpcodeFilters.astro";
@@ -17,57 +15,57 @@ import OpcodeFilters from "../../../../components/OpcodeFilters.astro";
      data-version="v{{IntroducedVersion}}"
      data-groups="{{csv Groups}}">
 
-<details>
-  <summary>
-    <table class='opcode-table'>
-      <thead>
-        <tr>
-          <th>Bytecode</th>
-          <th>Stack Input</th>
-          <th>Stack Output</th>
-          <th>Size</th>
-          <th>Availability</th>
-          <th>Cost</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>{{bytecode Opcode}}</td>
-          <td>{{{valueList Args}}}</td>
-          <td>{{{valueList Returns}}}</td>
-          <td>{{Size}}</td>
-          <td>v{{IntroducedVersion}}</td>
-          <td>{{DocCost}}</td>
-        </tr>
-      </tbody>
-    </table>
-</summary>
+    <details>
+    <summary>
+      <table class='opcode-table'>
+        <thead>
+          <tr>
+            <th>Bytecode</th>
+            <th>Stack Input</th>
+            <th>Stack Output</th>
+            <th>Size</th>
+            <th>Availability</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{bytecode Opcode}}</td>
+            <td>{{{valueList Args}}}</td>
+            <td>{{{valueList Returns}}}</td>
+            <td>{{Size}}</td>
+            <td>v{{IntroducedVersion}}</td>
+            <td>{{DocCost}}</td>
+          </tr>
+        </tbody>
+      </table>
+  </summary>
 
-  :::note[Details]
+    :::note[Details]
 
-  <span class="opcode-detail-caption">Description</span>
-  {{#if Doc}}
-  {{{mdxParagraphs Doc}}}
-  {{else}}
-  None
-  {{/if}}
+    <span class="opcode-detail-caption">Description</span>
+    {{#if Doc}}
+    {{{mdxParagraphs Doc}}}
+    {{else}}
+    None
+    {{/if}}
 
-  {{#if DocExtra}}
-  <span class="opcode-detail-caption">Notes</span>
-  {{{mdxParagraphs DocExtra}}}
-  {{/if}}
+    {{#if DocExtra}}
+    <span class="opcode-detail-caption">Notes</span>
+    {{{mdxParagraphs DocExtra}}}
+    {{/if}}
 
-  <span class='opcode-detail-caption'>Groups</span>
-  {{groupList Groups}}
+    <span class='opcode-detail-caption'>Groups</span>
+    {{groupList Groups}}
 
-  {{#if ImmediateNote}}
-  <span class="opcode-detail-caption">Immediate Parameters</span>
-  {{{immediateTable ImmediateNote}}}
-  {{/if}}
+    {{#if ImmediateNote}}
+    <span class="opcode-detail-caption">Immediate Parameters</span>
+    {{{immediateTable ImmediateNote}}}
+    {{/if}}
 
-  :::
+    :::
 
-</details>
+  </details>
 
 </div>
 


### PR DESCRIPTION
# ℹ Overview

Removed TOC component from opcode list page; does not currently work with the client-side filter. Will either add a text filter for opcode names, or override the Starlight TOC component to enable TOC items to be hidden when a filter is applied.

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [ ] Lint passes