### PR TITLE
Update code examples for Puya TS 1.0

### DIFF
--- a/src/content/docs/concepts/smart-contracts/storage/box.mdx
+++ b/src/content/docs/concepts/smart-contracts/storage/box.mdx
@@ -182,7 +182,7 @@ when using either opcode to read the contents of a box, the AVM is limited to re
   <TabItem label='Python' icon='seti:python'>
     <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/smart_contracts/box_storage/contract.py'
-      snippet='EXTRACT_BOX_REF'
+      snippet='EXTRACT_BOX'
       lang='py'
       title='Extract Box Reference'
       frame='none'
@@ -294,16 +294,16 @@ Here are some methods that can be used with box reference to splice, replace and
   <TabItem label='Algorand TypeScript' icon='seti:typescript'>
     <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/typescript-examples/contracts/BoxStorage/contract.algo.ts'
-      snippet='OTHER_OPS_BOX'
+      snippet='EXTRACT_BOX_STORAGE'
       lang='ts'
-      title='Delete Box Storage'
+      title='Other operations Box Storage'
       frame='none'
     />
   </TabItem>
   <TabItem label='Python' icon='seti:python'>
     <RemoteCode
       src='https://raw.githubusercontent.com/algorandfoundation/devportal-code-examples/refs/heads/main/projects/python-examples/smart_contracts/box_storage/contract.py'
-      snippet='OTHER_OPS_BOX_REF'
+      snippet='EXTRACT_BOX'
       lang='py'
       title='Other operations Box Storage'
       frame='none'


### PR DESCRIPTION
# ℹ Overview

Puya TS 1.0 deprecates the BoxRef API, so those examples will be merged/removed where appropriate in the [code examples repo PR](https://github.com/algorandfoundation/devportal-code-examples/pull/58). This PR ensures that the correct example code is used once those changes are merged.

**NOTE**: Should merge this AFTER the PR in the code example repo is merged.