### PR TITLE
fix: correct broken Other Fields link on blocks page

### DIFF
--- a/src/content/docs/concepts/transactions/blocks.mdx
+++ b/src/content/docs/concepts/transactions/blocks.mdx
@@ -21,7 +21,7 @@ The block header contains high-level metadata about the block:
 - **Proposer**: The account chosen (via VRF) to propose the block.
 - **Previous Block Hash**: Reference linking this block to its predecessor.
 - **Genesis ID / Hash**: Identifiers anchoring the chain back to its genesis block.
-- [Other Fields](https://github.com/algorandfoundation/specs/blob/master/dev/ledger.md#blocks)
+- [Other Fields](#block-fields)
 
 ### Body
 


### PR DESCRIPTION
## Summary
- The "Other Fields" bullet under the Header section on `/concepts/transactions/blocks` linked to `https://github.com/algorandfoundation/specs/blob/master/dev/ledger.md#blocks`, which 404s.
- Repointed the link to the in-page `#block-fields` anchor (the `## Block Fields` section already exists further down the same page).

## Test plan
- [x] Verify `/concepts/transactions/blocks` renders the "Other Fields" link as an in-page anchor.
- [x] Confirm clicking it scrolls to the `## Block Fields` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)