### PR TITLE
Remove GTM and reinstall Plausible for analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -106,7 +106,11 @@ export default defineConfig({
       head: [
         {
           tag: 'script',
-          content: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5XBZ7HB');`,
+          attrs: { src: 'https://plausible.io/js/pa-LzVeE3NPLc74nQKRGDgxI.js' },
+        },
+        {
+          tag: 'script',
+          content: `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`,
         },
         {
           tag: 'script',


### PR DESCRIPTION
# ℹ Overview

Removes Google Tag Manager and reimplements analytics via Plausible.