### PR TITLE
perf: defer Plausible & Kapa scripts to unblock page rendering

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -106,7 +106,10 @@ export default defineConfig({
       head: [
         {
           tag: 'script',
-          attrs: { src: 'https://plausible.io/js/pa-LzVeE3NPLc74nQKRGDgxI.js' },
+          attrs: {
+            src: 'https://plausible.io/js/pa-LzVeE3NPLc74nQKRGDgxI.js',
+            defer: true,
+          },
         },
         {
           tag: 'script',
@@ -116,6 +119,7 @@ export default defineConfig({
           tag: 'script',
           attrs: {
             src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+            defer: true,
             'data-website-id': '6e799942-b20a-4203-8103-93582a2611e1',
             'data-project-name': 'Algorand',
             'data-color-scheme-selector': "[data-theme='dark']",


### PR DESCRIPTION
# ℹ Overview

This PR defers loading scripts for Plausible analytics and Kapa.ai's chat overlay so they do not block page rendering. The previous blocking approach to loading these third-party scripts could cause significant delays in page rendering on slow connections.