### PR TITLE
Update close remainder to

### DIFF
--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -65,7 +65,7 @@ To implement payment transactions in your code, you can use the following exampl
 
 ### Close an Account
 
-In normal operation, an account holder can transfer their spendable balance to another account by sending a standard payment transaction, without using the `close` field. Only a payment that reduces the balance to exactly zero removes the account from the ledger. Any other amount leaves it with less than a full transfer completed. This option requires calculating the exact remaining balance at submission time.
+In normal operation, an account holder can transfer their spendable balance to another account by sending a standard payment transaction, without using the `close` field. For example, if account A has a balance of 1 Algo, A could send a normal payment of 0.999 Algo (balance minus the 0.001 Algo fee) to account B, with no `close` field set. Only a payment that reduces the balance to exactly zero removes the account from the ledger. Any other amount leaves it with less than a full transfer completed. This option requires calculating the exact remaining balance at submission time.
 
 The `close` field, also known as `CloseRemainderTo`, provides a reliable mechanism for emptying and closing an account. Rather than requiring the sender to calculate an exact amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
 

--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -65,7 +65,11 @@ To implement payment transactions in your code, you can use the following exampl
 
 ### Close an Account
 
-Closing an account removes it from the Algorand ledger. Due to the minimum balance requirement for all accounts, the only way to completely remove an account is to use the `close` field, also known as Close Remainder To, as shown in the transaction below:
+In normal operation, an account holder can empty their account by sending a payment transaction for its exact spendable balance (accounting for the transaction fee), without using the `close` field. This leaves the account with a zero balance, but the account itself still exists on the ledger.
+
+The `close` field, also known as Close Remainder To, is the recommended mechanism when the goal is to both transfer any remaining balance and close the account. Rather than requiring the sender to calculate an exact spendable amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger.
+
+Here is an example transaction using the `close` field:
 
 ```json showLineNumbers=false frame=none
 {

--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -65,9 +65,9 @@ To implement payment transactions in your code, you can use the following exampl
 
 ### Close an Account
 
-In normal operation, an account holder can transfer their entire spendable balance by sending a payment transaction for the account's spendable balance (account balance minus the minimum balance requirement and transaction fee), without using the `close` field. This leaves the account holding its minimum balance requirement, and the account continues to exist on the ledger.
+In normal operation, an account holder can transfer their spendable balance to another account by sending a standard payment transaction, without using the `close` field. Only a payment that reduces the balance to exactly zero removes the account from the ledger. Any other amount leaves it with less than a full transfer completed. This option requires calculating the exact remaining balance at submission time.
 
-The `close` field, also known as `CloseRemainderTo`, transfers any remaining balance after the transaction amount and fee are deducted to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
+The `close` field, also known as `CloseRemainderTo`, provides a reliable mechanism for emptying and closing an account. Rather than requiring the sender to calculate an exact amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
 
 Here is an example transaction using the `close` field:
 

--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -67,7 +67,7 @@ To implement payment transactions in your code, you can use the following exampl
 
 In normal operation, an account holder can empty their account by sending a payment transaction for its exact spendable balance (accounting for the transaction fee), without using the `close` field. This leaves the account with a zero balance, but the account itself still exists on the ledger.
 
-The `close` field, also known as Close Remainder To, is the recommended mechanism when the goal is to both transfer any remaining balance and close the account. Rather than requiring the sender to calculate an exact spendable amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger.
+The `close` field, also known as Close Remainder To, transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger.
 
 Here is an example transaction using the `close` field:
 

--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -65,9 +65,9 @@ To implement payment transactions in your code, you can use the following exampl
 
 ### Close an Account
 
-In normal operation, an account holder can transfer their spendable balance to another account by sending a standard payment transaction, without using the `close` field. For example, if account A has a balance of 1 Algo, A could send a normal payment of 0.999 Algo (balance minus the 0.001 Algo fee) to account B, with no `close` field set. Only a payment that reduces the balance to exactly zero removes the account from the ledger. Any other amount leaves it with less than a full transfer completed. This option requires calculating the exact remaining balance at submission time.
+Closing an account removes it from the Algorand ledger. Due to the minimum balance requirement (MBR), the most reliable and conventional way to completely remove an account is to use the close field (also known as CloseRemainderTo) in a payment transaction.
 
-The `close` field, also known as `CloseRemainderTo`, provides a reliable mechanism for emptying and closing an account. Rather than requiring the sender to calculate an exact amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
+The `close` field provides a reliable mechanism for emptying and closing an account. Rather than requiring the sender to calculate an exact amount, `close` transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
 
 Here is an example transaction using the `close` field:
 
@@ -115,6 +115,8 @@ To create a close account transaction in your code, refer to the following examp
     />
   </TabItem>
 </Tabs>
+
+Alternatively, you can close an account by transferring the spendable balance using a standard payment transaction without the `close` field. For example, if account A has a balance of 1 Algo, A could send a normal payment of 0.999 Algo (balance minus the 0.001 Algo fee) to account B, with no `close` field set. Only a payment that reduces the balance to exactly zero removes the account from the ledger. Any other amount leaves it with less than a full transfer completed. This option requires calculating the exact remaining balance at submission time.
 
 ## Key Registration Transaction
 

--- a/src/content/docs/concepts/transactions/types.mdx
+++ b/src/content/docs/concepts/transactions/types.mdx
@@ -65,9 +65,9 @@ To implement payment transactions in your code, you can use the following exampl
 
 ### Close an Account
 
-In normal operation, an account holder can empty their account by sending a payment transaction for its exact spendable balance (accounting for the transaction fee), without using the `close` field. This leaves the account with a zero balance, but the account itself still exists on the ledger.
+In normal operation, an account holder can transfer their entire spendable balance by sending a payment transaction for the account's spendable balance (account balance minus the minimum balance requirement and transaction fee), without using the `close` field. This leaves the account holding its minimum balance requirement, and the account continues to exist on the ledger.
 
-The `close` field, also known as Close Remainder To, transfers any remaining balance, after the transaction amount and fee are deducted, to the designated close-to account and removes the account from the ledger.
+The `close` field, also known as `CloseRemainderTo`, transfers any remaining balance after the transaction amount and fee are deducted to the designated close-to account and removes the account from the ledger. To successfully close an account, it must first no longer hold any assets or application state that contribute to its minimum balance requirement.
 
 Here is an example transaction using the `close` field:
 


### PR DESCRIPTION
Updates the "Close an Account" section to clarify that an account can be emptied by sending its exact spendable balance (leaving a zero balance, but not closing the account), and that the close field is what transfers any remainder and removes the account from the ledger. Wording is now neutral/descriptive rather than implying close is the only option.

