### PR TITLE
Docs: Add poseidon2 opcode

### DIFF
--- a/src/content/docs/concepts/smart-contracts/avm.md
+++ b/src/content/docs/concepts/smart-contracts/avm.md
@@ -516,6 +516,7 @@ these results may contain leading zero bytes.
 | `ec_subgroup_check g`   | 1 if A is in the main prime-order subgroup of G (including the point at infinity) else 0. Program fails if A is not in G at all.                  |
 | `ec_map_to g`           | maps field element A to group G                                                                                                                   |
 | `mimc c`                | MiMC hash of scalars A, using curve and parameters specified by configuration C                                                                   |
+| `poseidon2 c`           | Poseidon2 hash of scalars A, using curve and parameters specified by configuration C                                                              |
 
 ### Loading Values
 

--- a/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
+++ b/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
@@ -31,6 +31,7 @@ A hash function maps data of arbitrary size to fixed-size values. The following 
 - `keccak256`
 - `sha512_256`
 - `mimc`
+- `poseidon2`
 - `vFuture: sumhash512`
 
 Note that `sha512_256` is _not_ the same as `sha512(x) % 2^256`.
@@ -38,6 +39,8 @@ Note that `sha512_256` is _not_ the same as `sha512(x) % 2^256`.
 MiMC is a ZK-friendly hash function enjoying popularity for ZK-SNARK applications. Note that it is not designed to be used in general applications, but rather in ZK-related applications - hence the increased cost compared to the other hash functions.
 
 MiMC will result in a minimal circuit size compared to SHA-2 or SHA-3 hash functions, making generating ZK-SNARKs cheaper. It also comes in two flavors: BN254 and BLS12_381.
+
+Poseidon2 is currently the most popular ZK-friendly hash function and is used by production proving systems such as SP1, RISC Zero, and Plonky3. Compared to MiMC it is more efficient, resulting in lower opcode costs on-chain and smaller circuits off-chain. Like MiMC, it is intended for ZK-related applications rather than general use, and it comes in two flavors: BN254 and BLS12_381.
 
 SumHash512 strives to strike a balance between ZK and non-ZK friendliness. It is currently seeing use in State Proofs, namely in constructing the VoterCommitment, a Merkle tree commitment committing to the top stakers.
 

--- a/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
+++ b/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
@@ -40,7 +40,7 @@ MiMC is a ZK-friendly hash function enjoying popularity for ZK-SNARK application
 
 MiMC will result in a minimal circuit size compared to SHA-2 or SHA-3 hash functions, making generating ZK-SNARKs cheaper. It also comes in two flavors: BN254 and BLS12_381.
 
-Poseidon2 is currently the most popular ZK-friendly hash function and is used by production proving systems such as SP1, RISC Zero, and Plonky3. Compared to MiMC it is more efficient, resulting in lower opcode costs on-chain and smaller circuits off-chain. Like MiMC, it is intended for ZK-related applications rather than general use, and it comes in two flavors: BN254 and BLS12_381.
+Poseidon2 is a ZK-friendly hash function used by proving systems such as SP1, RISC Zero, and Plonky3. Compared to MiMC, it is more efficient, resulting in lower opcode costs on-chain and smaller circuits off-chain. Like MiMC, it is intended for ZK-related applications rather than general use, and it comes in two flavors: BN254 and BLS12_381.
 
 SumHash512 strives to strike a balance between ZK and non-ZK friendliness. It is currently seeing use in State Proofs, namely in constructing the VoterCommitment, a Merkle tree commitment committing to the top stakers.
 


### PR DESCRIPTION
## Proposed Changes

- Adds `poseidon2` to the cryptographic tools page
- Adds the `poseidon2 c` row to the AVM page's opcode table
- Based on algorand/go-algorand#6560 (AVM v13)