### PR TITLE
Docs: Add sha512 opcode

### DIFF
--- a/src/content/docs/concepts/smart-contracts/avm.md
+++ b/src/content/docs/concepts/smart-contracts/avm.md
@@ -501,6 +501,7 @@ these results may contain leading zero bytes.
 | `sha256`                | SHA256 hash of value A, yields [32]byte                                                                                                           |
 | `keccak256`             | Keccak256 hash of value A, yields [32]byte                                                                                                        |
 | `sha512_256`            | SHA512_256 hash of value A, yields [32]byte                                                                                                       |
+| `sha512`                | SHA512 hash of value A, yields [64]byte                                                                                                           |
 | `sha3_256`              | SHA3_256 hash of value A, yields [32]byte                                                                                                         |
 | `falcon_verify`         | for (data A, compressed-format signature B, pubkey C) verify the signature of data against the pubkey => {0 or 1}                                 |
 | `ed25519verify`         | for (data A, signature B, pubkey C) verify the signature of ("ProgData" \|\| program_hash \|\| data) against the pubkey => {0 or 1}               |

--- a/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
+++ b/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
@@ -30,10 +30,13 @@ A hash function maps data of arbitrary size to fixed-size values. The following 
 - `sha256`
 - `keccak256`
 - `sha512_256`
+- `sha512`
 - `mimc`
 - `vFuture: sumhash512`
 
 Note that `sha512_256` is _not_ the same as `sha512(x) % 2^256`.
+
+SHA512 produces the full 64-byte digest, offering a higher security level than the 32-byte `sha512_256`. Its cost scales with the length of the input.
 
 MiMC is a ZK-friendly hash function enjoying popularity for ZK-SNARK applications. Note that it is not designed to be used in general applications, but rather in ZK-related applications - hence the increased cost compared to the other hash functions.
 

--- a/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
+++ b/src/content/docs/concepts/smart-contracts/cryptographic-tools.mdx
@@ -36,7 +36,7 @@ A hash function maps data of arbitrary size to fixed-size values. The following 
 
 Note that `sha512_256` is _not_ the same as `sha512(x) % 2^256`.
 
-SHA512 produces the full 64-byte digest, offering a higher security level than the 32-byte `sha512_256`. Its cost scales with the length of the input.
+The `sha512` opcode produces the full 64-byte digest, offering a higher security level than the 32-byte `sha512_256`. Its cost scales with the length of the input.
 
 MiMC is a ZK-friendly hash function enjoying popularity for ZK-SNARK applications. Note that it is not designed to be used in general applications, but rather in ZK-related applications - hence the increased cost compared to the other hash functions.
 


### PR DESCRIPTION
## Proposed Changes

- Adds `sha512` to the cryptographic tools page
- Adds the `sha512` row to the AVM page's opcode table
- Based on [AVM: sha512 opcode algorand/go-algorand#6424](https://github.com/algorand/go-algorand/pull/6424) (AVM v13)