### PR TITLE
Docs: Remove deprecated tealdbg

### DIFF
--- a/src/content/docs/nodes/installation/manual-installation.mdx
+++ b/src/content/docs/nodes/installation/manual-installation.mdx
@@ -219,7 +219,6 @@ utilities:
 - `catchupsrv`
 - `msgpacktool`
 - `tealcut`
-- `tealdbg`
 
 Installation is straightforward using your system's package manager (`apt` or `yum`). The package
 manager will handle dependencies automatically:


### PR DESCRIPTION
## Proposed Changes

- Removes deprecated `tealdbg` from the developer tools list on the manual installation page
- The `/algokit/cli/localnet` mention is synced from the [algokit-cli repo](https://github.com/algorandfoundation/algokit-cli) - will work on a PR there to remove it
- The 2022 architecture decision record mentions tealdbg but is a historical document, left as is