### PR TITLE
docs: address post-quantum feedback

### DIFF
--- a/src/content/docs/concepts/accounts/post-quantum.mdx
+++ b/src/content/docs/concepts/accounts/post-quantum.mdx
@@ -51,11 +51,11 @@ address = SHA512-256("PQA" || scheme || salt || public key)
 
 The result is encoded with a checksum into the same 58-character format as every other Algorand address. On-chain, a post-quantum address is indistinguishable from any other address; it acquires meaning only when a transaction proves ownership with a matching `pqsig`.
 
-The hashing step also means a post-quantum address cannot be decoded back to its public key. An Ed25519 address is a direct encoding of the public key, so that key is visible to any would-be attacker from the moment the account exists. A post-quantum address reveals nothing about its key until the account first spends and the public key appears in the transaction's `pqsig` envelope, a potentially useful side effect for accounts that want to keep their key hidden until first spend.
+The hash serves two purposes. First, an Ed25519 address can directly encode its 32-byte public key, but a Falcon-1024 public key is about 1.8 KB, so it must be hashed down to fit the 32-byte address format. Second, hashing with a salt maintains domain separation between signature schemes: a post-quantum address is never a valid Ed25519 public key, regardless of a scheme's key size. The next section explains why this matters.
 
 ### The Salt Byte
 
-The one-byte salt exists so that key generation can search for an address that is **not a valid point on the Ed25519 curve**. An off-curve address can never collide with, or be claimed by, any Ed25519 key pair, which cleanly separates the two account populations.
+The one-byte salt exists so that key generation can search for an address that is **not a valid point on the Ed25519 curve**. A quantum computer can recover the private key behind any Ed25519 public key, so if a post-quantum address were also a valid Ed25519 public key, a quantum attacker could compute the matching private key and spend from the account with an ordinary `sig`. Because an off-curve address can never be claimed by any Ed25519 key pair, this attack is ruled out entirely.
 
 Two subtleties are worth understanding:
 

--- a/src/content/docs/concepts/accounts/post-quantum.mdx
+++ b/src/content/docs/concepts/accounts/post-quantum.mdx
@@ -34,7 +34,7 @@ A signed Algorand transaction carries exactly one of four signature categories:
 
 The `pqsig` field is a scheme-agnostic envelope with four parts:
 
-- `sch`: the signature scheme identifier. `f1` is Falcon-1024, the only scheme currently enabled. (`f2` is reserved for Falcon-512, which is defined but not enabled.)
+- `sch`: the signature scheme identifier. `f1` is Falcon-1024, the only scheme currently enabled. (`f5` is reserved for Falcon-512, which is defined but not enabled.)
 - `slt`: a one-byte salt used in address derivation (see below).
 - `pk`: the post-quantum public key.
 - `sig`: the signature itself.

--- a/src/content/docs/concepts/accounts/post-quantum.mdx
+++ b/src/content/docs/concepts/accounts/post-quantum.mdx
@@ -76,7 +76,7 @@ Falcon private keys and signatures are substantially larger than their Ed25519 c
 
 ## Fees
 
-The minimum fee for a transaction is the sum of a base fee and per-scheme contributions. A Falcon-1024 signature contributes an additional **2× the base minimum fee**, so with the current base of 1,000 µAlgo:
+The minimum fee for a transaction is the sum of a base fee and per-scheme contributions. A Falcon-1024 signature contributes an additional **2× the base fee**, so with the current base fee of 1,000 µAlgo:
 
 | Transaction        | Minimum fee                  |
 | ------------------ | ---------------------------- |

--- a/src/content/docs/concepts/transactions/fees.mdx
+++ b/src/content/docs/concepts/transactions/fees.mdx
@@ -12,9 +12,9 @@ Blockchains like Algorand are decentralized networks with finite computational r
 
 ## Minimum Fee
 
-The base minimum fee for each transaction on Algorand is 1,000 microAlgo (0.001 Algo), and it is **fixed** to this amount when the network is not congested.
+The base fee for each transaction on Algorand is 1,000 microAlgo (0.001 Algo), and it is **fixed** to this amount when the network is not congested.
 
-The signature scheme that authorizes a transaction can add a contribution on top of the base. [Post-quantum signatures](/concepts/accounts/post-quantum) are much larger than Ed25519 signatures, and a Falcon-1024 signature adds a contribution of 2× the base minimum fee:
+The signature scheme that authorizes a transaction can add a contribution on top of the base fee. [Post-quantum signatures](/concepts/accounts/post-quantum) are much larger than Ed25519 signatures, and a Falcon-1024 signature adds a contribution of 2× the base fee:
 
 | Authorized by                                                       | Minimum fee                  |
 | ------------------------------------------------------------------- | ---------------------------- |

--- a/src/content/docs/concepts/transactions/signing.mdx
+++ b/src/content/docs/concepts/transactions/signing.mdx
@@ -214,7 +214,7 @@ A transaction from a [post-quantum account](/concepts/accounts/post-quantum) is 
 - `pk`: the post-quantum public key, which the network hashes together with `sch` and `slt` to confirm it matches the authorizing address.
 - `sig`: the signature over the transaction.
 
-Because post-quantum signatures are substantially larger than Ed25519 signatures, transactions authorized by a `pqsig` pay a higher minimum fee, currently 3,000 microAlgo (0.003 Algo). See [Transaction Fees](/concepts/transactions/fees) for details.
+Because post-quantum signatures are substantially larger than Ed25519 signatures, transactions authorized by a `pqsig` pay a higher minimum fee — the base fee plus a Falcon contribution of 2× the base fee, currently 3,000 microAlgo (0.003 Algo) in total. See [Transaction Fees](/concepts/transactions/fees) for details.
 
 :::note
 Post-quantum signing requires the v42 consensus upgrade (algod v5.0.0) to be in effect on the target network. Wallet and SDK support is rolling out; check your tooling's release notes.


### PR DESCRIPTION
  - Falcon-512 scheme identifier is `f5` not `f2`
  - rewrote the address hashing rationale: the hash exists because Falcon keys are too big for 32 bytes and to keep post-quantum addresses from ever being valid Ed25519 keys, NOT to conceal the public key
  - standardized on "base fee" for the 1,000 microalgo component, keeping "minimum fee" for the total a transaction must pay"