### PR TITLE
fix: exclude imports/ from type-checking to unblock lint and build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ Ensure the following acceptance criteria are met before submitting a PR:
 - Ensure `pnpm run lint` passes
 - Ensure `pnpm run build` passes
 
+> **Troubleshooting:** If `pnpm run build` fails with `Cannot find module .../dist/chunks/*.mjs`, clear stale build artifacts and retry: `rm -rf dist node_modules/.vite .astro`. This is a cached-chunk issue from a previous build, not a problem with your changes.
+
 ### Publishing [TBD]
 
 Production deployment from `main-dist` branch to CloudFlare Pages. PRs can be previewed in CF Pages as well.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "exclude": ["./examples", "./dist", "./scripts/library-templates", "./tests"]
+  "exclude": ["./examples", "./dist", "./scripts/library-templates", "./tests", "./imports"]
 }


### PR DESCRIPTION
## Problem

`imports/repos/` holds external repos cloned for docs generation. ESLint already ignores `imports/*` (`eslint.config.js`), but `tsconfig.json` did not exclude it, so `astro check` type-checked that vendored code (minified jQuery, deprecated SDK calls, unused vars, CommonJS modules) and failed with thousands of errors. That broke both `pnpm run lint` and `pnpm run build` (which runs `astro check` first) in any clone where `imports/repos/` is populated.

## Fix

Add `./imports` to the `exclude` array in `tsconfig.json`, aligning `astro check` with ESLint's existing ignore. One-line change; no project source is affected.

## Also

Added a build-troubleshooting note to `CONTRIBUTING.md` for a stale-`dist` failure (`Cannot find module .../dist/chunks/*.mjs`). This is a general Astro gotcha from building on top of old artifacts, independent of this change, but it's a common footgun so it's worth documenting next to the build requirement.

## Validation

- `pnpm run lint` -> 0 errors / 0 warnings / 0 hints (57 files, down from 1007)
- `pnpm run build` (clean) -> 1665 pages built, all internal links valid, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
