### PR TITLE
fix: give the algod/indexer/kmd landing pages actual content

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ Before you begin, ensure you have the following installed:
 ├── imports/
 │   ├── configs/           # GitHub loader import configurations
 │   └── transforms/        # Content transformation utilities
+├── openapi/               # Vendored algod/indexer/kmd OpenAPI specs (generated)
 ├── public/                # Static assets (favicons, etc.)
 ├── scripts/               # Build and utility scripts
 │   ├── clean-docs-import.ts       # Clear imported documentation
 │   ├── generate-opcode-list.ts    # Render the opcode reference page
+│   ├── generate-openapi-schemas.ts # Vendor the REST API OpenAPI specs
 │   ├── manage-sidebar-meta.ts     # Sidebar metadata generator
 │   ├── prose-check.ts             # AI-powered prose quality checker
 │   └── update-opcodes.ts          # Sync TEAL opcodes from go-algorand
@@ -162,8 +164,9 @@ All commands are run from the root of the project:
 | `pnpm run update:opcodes`         | Fetch the latest opcodes from go-algorand, update `opcodes.json`, and re-render |
 | `pnpm run update:opcodes:dry-run` | Preview an opcode update without writing any files                              |
 | `pnpm run check:opcodes`          | Warn (non-blocking) if the committed opcode reference is out of date            |
+| `pnpm run generate:openapi`       | Re-vendor the algod/indexer/kmd OpenAPI specs into `openapi/`                   |
 
-See [TEAL Opcode Reference](#teal-opcode-reference) for how these fit together.
+See [TEAL Opcode Reference](#teal-opcode-reference) and [REST API Reference](#rest-api-reference) for how these fit together.
 
 ### Content Import
 
@@ -264,6 +267,14 @@ The [AVM Opcodes](https://dev.algorand.co/reference/algorand-teal/opcodes) refer
 - `opcodes.json` is the dataset; `opcodes.mdx` is rendered from it (auto, in `prebuild`).
 - `check:opcodes` runs during `prebuild` and prints a non-blocking warning when the dataset is out of date.
 - To refresh, run **Actions → Update Opcodes → Run workflow** (opens a `devrel`-reviewed PR), or run `pnpm run update:opcodes` locally on a dedicated branch.
+
+### REST API Reference
+
+The [algod](https://dev.algorand.co/reference/rest-api/algod), [indexer](https://dev.algorand.co/reference/rest-api/indexer) and [kmd](https://dev.algorand.co/reference/rest-api/kmd) references are rendered by `starlight-openapi` from OpenAPI specs vendored into `openapi/`.
+
+- `scripts/generate-openapi-schemas.ts` fetches each upstream spec, rewrites `info.title` and `info.description`, and writes `openapi/{algod,indexer,kmd}.json`. The output is committed; refresh it with `pnpm run generate:openapi` on a dedicated branch.
+- Overwriting `info.description` is the reason the specs are vendored rather than read from their upstream URLs. `starlight-openapi` builds each API's landing page from `info` alone, so that field is the entire page, and upstream ships a single sentence there.
+- Nothing else in the spec is modified, so operation pages stay faithful to upstream.
 
 ## Contributing
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -123,8 +123,7 @@ export default defineConfig({
         starlightOpenAPI([
           {
             base: 'reference/rest-api/algod',
-            schema:
-              'https://raw.githubusercontent.com/algorand/go-algorand/refs/heads/master/daemon/algod/api/algod.oas3.yml',
+            schema: './openapi/algod.json',
             sidebar: {
               label: 'algod',
               group: algodAPIDocsSidebarGroup,
@@ -134,8 +133,7 @@ export default defineConfig({
           },
           {
             base: 'reference/rest-api/indexer',
-            schema:
-              'https://raw.githubusercontent.com/algorand/indexer/refs/heads/main/api/indexer.oas3.yml',
+            schema: './openapi/indexer.json',
             sidebar: {
               label: 'indexer',
               group: indexerAPIDocsSidebarGroup,
@@ -145,8 +143,7 @@ export default defineConfig({
           },
           {
             base: 'reference/rest-api/kmd',
-            schema:
-              'https://raw.githubusercontent.com/algorand/go-algorand/ad578576ab5f5bfe58a590164903617ecef379e4/daemon/kmd/api/swagger.json',
+            schema: './openapi/kmd.json',
             sidebar: {
               label: 'kmd',
               group: kmdAPIDocsSidebarGroup,

--- a/openapi/algod.json
+++ b/openapi/algod.json
@@ -1,0 +1,7957 @@
+{
+  "components": {
+    "parameters": {
+      "address": {
+        "description": "An account public key.",
+        "in": "path",
+        "name": "address",
+        "required": true,
+        "schema": {
+          "pattern": "[A-Z0-9]{58}",
+          "type": "string",
+          "x-go-type": "basics.Address"
+        },
+        "x-go-type": "basics.Address"
+      },
+      "application-id": {
+        "description": "An application identifier.",
+        "in": "path",
+        "name": "application-id",
+        "required": true,
+        "schema": {
+          "minimum": 0,
+          "type": "integer",
+          "x-go-type": "basics.AppIndex"
+        },
+        "x-go-type": "basics.AppIndex"
+      },
+      "asset-id": {
+        "description": "An asset identifier.",
+        "in": "path",
+        "name": "asset-id",
+        "required": true,
+        "schema": {
+          "minimum": 0,
+          "type": "integer",
+          "x-go-type": "basics.AssetIndex"
+        },
+        "x-go-type": "basics.AssetIndex"
+      },
+      "catchpoint": {
+        "description": "A catch point",
+        "in": "path",
+        "name": "catchpoint",
+        "required": true,
+        "schema": {
+          "format": "catchpoint",
+          "pattern": "[0-9]{1,10}#[A-Z0-9]{1,53}",
+          "type": "string",
+          "x-algorand-format": "Catchpoint String"
+        },
+        "x-algorand-format": "Catchpoint String"
+      },
+      "format": {
+        "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+        "in": "query",
+        "name": "format",
+        "schema": {
+          "enum": [
+            "json",
+            "msgpack"
+          ],
+          "type": "string"
+        }
+      },
+      "include": {
+        "description": "Include additional items in the response. Use `params` to include full application parameters (global state, schema, etc.). Multiple values can be comma-separated. Defaults to returning only application IDs and local state.",
+        "explode": false,
+        "in": "query",
+        "name": "include",
+        "schema": {
+          "items": {
+            "enum": [
+              "params"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "style": "form"
+      },
+      "limit": {
+        "description": "Maximum number of results to return.",
+        "in": "query",
+        "name": "limit",
+        "schema": {
+          "type": "integer",
+          "x-go-type": "uint64"
+        },
+        "x-go-type": "uint64"
+      },
+      "max": {
+        "description": "Truncated number of transactions to display. If max=0, returns all pending txns.",
+        "in": "query",
+        "name": "max",
+        "schema": {
+          "type": "integer",
+          "x-go-type": "uint64"
+        },
+        "x-go-type": "uint64"
+      },
+      "next": {
+        "description": "The next page of results. Use the next token provided by the previous results.",
+        "in": "query",
+        "name": "next",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "round": {
+        "description": "A round number.",
+        "in": "path",
+        "name": "round",
+        "required": true,
+        "schema": {
+          "minimum": 0,
+          "type": "integer",
+          "x-go-type": "basics.Round"
+        },
+        "x-go-type": "basics.Round"
+      },
+      "sig-type": {
+        "description": "SigType filters just results using the specified type of signature:\n* sig - Standard\n* msig - MultiSig\n* lsig - LogicSig\n* pqsig - Post-Quantum",
+        "in": "query",
+        "name": "sig-type",
+        "schema": {
+          "enum": [
+            "sig",
+            "msig",
+            "lsig",
+            "pqsig"
+          ],
+          "type": "string"
+        }
+      },
+      "tx-id": {
+        "description": "Lookup the specific transaction by ID.",
+        "in": "query",
+        "name": "tx-id",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "Address",
+          "x-go-name": "TxID"
+        },
+        "x-algorand-format": "Address",
+        "x-go-name": "TxID"
+      },
+      "tx-type": {
+        "in": "query",
+        "name": "tx-type",
+        "schema": {
+          "enum": [
+            "pay",
+            "keyreg",
+            "acfg",
+            "axfer",
+            "afrz",
+            "appl",
+            "stpf"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "AccountApplicationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "app-local-state": {
+                  "$ref": "#/components/schemas/ApplicationLocalState"
+                },
+                "created-app": {
+                  "$ref": "#/components/schemas/ApplicationParams"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "AccountApplicationResponse describes the account's application local state and global state (AppLocalState and AppParams, if either exists) for a specific application ID. Global state will only be returned if the provided address is the application's creator."
+      },
+      "AccountApplicationsInformationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "application-resources": {
+                  "items": {
+                    "$ref": "#/components/schemas/AccountApplicationResource"
+                  },
+                  "type": "array"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter. The next token is the next application ID to use as the pagination cursor.",
+                  "type": "string"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "AccountApplicationsInformationResponse contains a list of application resources for an account."
+      },
+      "AccountAssetResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "asset-holding": {
+                  "$ref": "#/components/schemas/AssetHolding"
+                },
+                "created-asset": {
+                  "$ref": "#/components/schemas/AssetParams"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "AccountAssetResponse describes the account's asset holding and asset parameters (if either exist) for a specific asset ID. Asset parameters will only be returned if the provided address is the asset's creator."
+      },
+      "AccountAssetsInformationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "asset-holdings": {
+                  "items": {
+                    "$ref": "#/components/schemas/AccountAssetHolding"
+                  },
+                  "type": "array"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "AccountAssetsInformationResponse contains a list of assets held by an account."
+      },
+      "AccountResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Account"
+            }
+          }
+        },
+        "description": "AccountResponse wraps the Account type in a response."
+      },
+      "ApplicationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Application"
+            }
+          }
+        },
+        "description": "Application information"
+      },
+      "AssetResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Asset"
+            }
+          }
+        },
+        "description": "Asset information"
+      },
+      "BlockHashResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "blockHash": {
+                  "description": "Block header hash.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "blockHash"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Hash of a block header."
+      },
+      "BlockLogsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "logs": {
+                  "items": {
+                    "$ref": "#/components/schemas/AppCallLogs"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "logs"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "All logs emitted in the given round. Each app call, whether top-level or inner, that contains logs results in a separate AppCallLogs object. Therefore there may be multiple AppCallLogs with the same application ID and outer transaction ID in the event of multiple inner app calls to the same app. App calls with no logs are not included in the response. AppCallLogs are returned in the same order that their corresponding app call appeared in the block (pre-order traversal of inner app calls)"
+      },
+      "BlockResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "block": {
+                  "description": "Block header data.",
+                  "properties": {},
+                  "type": "object",
+                  "x-algorand-format": "BlockHeader"
+                },
+                "cert": {
+                  "description": "Optional certificate object. This is only included when the format is set to message pack.",
+                  "properties": {},
+                  "type": "object",
+                  "x-algorand-format": "BlockCertificate"
+                }
+              },
+              "required": [
+                "block"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Encoded block object."
+      },
+      "BlockTxidsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "blockTxids": {
+                  "description": "Block transaction IDs.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "blockTxids"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Top level transaction IDs in a block."
+      },
+      "BoxResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Box"
+            }
+          }
+        },
+        "description": "Box information"
+      },
+      "BoxesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "boxes": {
+                  "items": {
+                    "$ref": "#/components/schemas/BoxDescriptor"
+                  },
+                  "type": "array"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter. The next token is the box name to use as the pagination cursor, encoded in the goal app call arg form.",
+                  "type": "string"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "boxes"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Boxes of an application"
+      },
+      "CatchpointAbortResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "An catchpoint abort response.",
+              "properties": {
+                "catchup-message": {
+                  "description": "Catchup abort response string",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "catchup-message"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "CatchpointStartResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "An catchpoint start response.",
+              "properties": {
+                "catchup-message": {
+                  "description": "Catchup start response string",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "catchup-message"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "CompileResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "hash": {
+                  "description": "base32 SHA512_256 of program bytes (Address style)",
+                  "type": "string"
+                },
+                "result": {
+                  "description": "base64 encoded program bytes",
+                  "type": "string"
+                },
+                "sourcemap": {
+                  "description": "JSON of the source map",
+                  "properties": {},
+                  "type": "object"
+                }
+              },
+              "required": [
+                "hash",
+                "result"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Teal compile Result"
+      },
+      "DebugSettingsProfResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DebugSettingsProf"
+            }
+          }
+        },
+        "description": "DebugPprof is the response to the /debug/extra/pprof endpoint"
+      },
+      "DisassembleResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "result": {
+                  "description": "disassembled Teal code",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "result"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Teal disassembly Result"
+      },
+      "GetBlockTimeStampOffsetResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "offset": {
+                  "description": "Timestamp offset in seconds.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                }
+              },
+              "required": [
+                "offset"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Response containing the timestamp offset in seconds"
+      },
+      "GetPeersResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "Peers": {
+                  "items": {
+                    "$ref": "#/components/schemas/PeerStatus"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "Peers"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Response containing the network peers of the node"
+      },
+      "GetSyncRoundResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "round": {
+                  "description": "The minimum sync round for the ledger.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Response containing the ledger's minimum sync round"
+      },
+      "LedgerStateDeltaForTransactionGroupResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LedgerStateDelta"
+            }
+          }
+        },
+        "description": "Response containing a ledger state delta for a single transaction group."
+      },
+      "LedgerStateDeltaResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LedgerStateDelta"
+            }
+          }
+        },
+        "description": "Contains ledger deltas"
+      },
+      "LightBlockHeaderProofResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LightBlockHeaderProof"
+            }
+          }
+        },
+        "description": "Proof of a light block header."
+      },
+      "NodeStatusResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "NodeStatus contains the information about a node status",
+              "properties": {
+                "catchpoint": {
+                  "description": "The current catchpoint that is being caught up to",
+                  "type": "string"
+                },
+                "catchpoint-acquired-blocks": {
+                  "description": "The number of blocks that have already been obtained by the node as part of the catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-processed-accounts": {
+                  "description": "The number of accounts from the current catchpoint that have been processed so far as part of the catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-processed-kvs": {
+                  "description": "The number of key-values (KVs) from the current catchpoint that have been processed so far as part of the catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-total-accounts": {
+                  "description": "The total number of accounts included in the current catchpoint",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-total-blocks": {
+                  "description": "The total number of blocks that are required to complete the current catchpoint catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-total-kvs": {
+                  "description": "The total number of key-values (KVs) included in the current catchpoint",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-verified-accounts": {
+                  "description": "The number of accounts from the current catchpoint that have been verified so far as part of the catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchpoint-verified-kvs": {
+                  "description": "The number of key-values (KVs) from the current catchpoint that have been verified so far as part of the catchup",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "catchup-time": {
+                  "description": "CatchupTime in nanoseconds",
+                  "type": "integer",
+                  "x-go-type": "int64"
+                },
+                "last-catchpoint": {
+                  "description": "The last catchpoint seen by the node",
+                  "type": "string"
+                },
+                "last-round": {
+                  "description": "LastRound indicates the last round seen",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "last-version": {
+                  "description": "LastVersion indicates the last consensus version supported",
+                  "type": "string"
+                },
+                "next-version": {
+                  "description": "NextVersion of consensus protocol to use",
+                  "type": "string"
+                },
+                "next-version-round": {
+                  "description": "NextVersionRound is the round at which the next consensus version will apply",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "next-version-supported": {
+                  "description": "NextVersionSupported indicates whether the next consensus version is supported by this node",
+                  "type": "boolean"
+                },
+                "stopped-at-unsupported-round": {
+                  "description": "StoppedAtUnsupportedRound indicates that the node does not support the new rounds and has stopped making progress",
+                  "type": "boolean"
+                },
+                "time-since-last-round": {
+                  "description": "TimeSinceLastRound in nanoseconds",
+                  "type": "integer",
+                  "x-go-type": "int64"
+                },
+                "upgrade-delay": {
+                  "description": "Upgrade delay",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-next-protocol-vote-before": {
+                  "description": "Next protocol round",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-no-votes": {
+                  "description": "No votes cast for consensus upgrade",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-node-vote": {
+                  "description": "This node's upgrade vote",
+                  "type": "boolean"
+                },
+                "upgrade-vote-rounds": {
+                  "description": "Total voting rounds for current upgrade",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-votes": {
+                  "description": "Total votes cast for consensus upgrade",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-votes-required": {
+                  "description": "Yes votes required for consensus upgrade",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "upgrade-yes-votes": {
+                  "description": "Yes votes cast for consensus upgrade",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                }
+              },
+              "required": [
+                "catchup-time",
+                "last-round",
+                "last-version",
+                "next-version",
+                "next-version-round",
+                "next-version-supported",
+                "stopped-at-unsupported-round",
+                "time-since-last-round"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ParticipationKeyResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ParticipationKey"
+            }
+          }
+        },
+        "description": "A detailed description of a participation ID"
+      },
+      "ParticipationKeysResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/ParticipationKey"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "description": "A list of participation keys"
+      },
+      "PendingTransactionsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "PendingTransactions is an array of signed transactions exactly as they were submitted.",
+              "properties": {
+                "top-transactions": {
+                  "description": "An array of signed transaction objects.",
+                  "items": {
+                    "properties": {},
+                    "type": "object",
+                    "x-algorand-format": "SignedTransaction"
+                  },
+                  "type": "array"
+                },
+                "total-transactions": {
+                  "description": "Total number of transactions in the pool.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "top-transactions",
+                "total-transactions"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "A potentially truncated list of transactions currently in the node's transaction pool. You can compute whether or not the list is truncated if the number of elements in the **top-transactions** array is fewer than **total-transactions**."
+      },
+      "PostParticipationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "partId": {
+                  "description": "encoding of the participation ID.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "partId"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Participation ID of the submission"
+      },
+      "PostTransactionsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "txId": {
+                  "description": "encoding of the transaction hash.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "txId"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Transaction ID of the submission."
+      },
+      "SimulateResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "eval-overrides": {
+                  "$ref": "#/components/schemas/SimulationEvalOverrides"
+                },
+                "exec-trace-config": {
+                  "$ref": "#/components/schemas/SimulateTraceConfig"
+                },
+                "initial-states": {
+                  "$ref": "#/components/schemas/SimulateInitialStates"
+                },
+                "last-round": {
+                  "description": "The round immediately preceding this simulation. State changes through this round were used to run this simulation.",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "txn-groups": {
+                  "description": "A result object for each transaction group that was simulated.",
+                  "items": {
+                    "$ref": "#/components/schemas/SimulateTransactionGroupResult"
+                  },
+                  "type": "array"
+                },
+                "version": {
+                  "description": "The version of this response object.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                }
+              },
+              "required": [
+                "last-round",
+                "txn-groups",
+                "version"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Result of a transaction group simulation."
+      },
+      "StateProofResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/StateProof"
+            }
+          }
+        },
+        "description": "StateProofResponse wraps the StateProof type in a response."
+      },
+      "SupplyResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Supply represents the current supply of MicroAlgos in the system",
+              "properties": {
+                "current_round": {
+                  "description": "Round",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "online-money": {
+                  "description": "Total stake held by accounts with status Online at current_round, including those whose participation keys have expired but have not yet been marked offline.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "online-stake": {
+                  "description": "Online stake used by agreement to vote for current_round, excluding accounts whose participation keys have expired.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "total-money": {
+                  "description": "TotalMoney",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                }
+              },
+              "required": [
+                "current_round",
+                "online-money",
+                "online-stake",
+                "total-money"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Supply represents the current supply of MicroAlgos in the system."
+      },
+      "TransactionGroupLedgerStateDeltasForRoundResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "Deltas": {
+                  "items": {
+                    "$ref": "#/components/schemas/LedgerStateDeltaForTransactionGroup"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "Deltas"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Response containing all ledger state deltas for transaction groups, with their associated Ids, in a single round."
+      },
+      "TransactionParametersResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "TransactionParams contains the parameters that help a client construct\na new transaction.",
+              "properties": {
+                "consensus-version": {
+                  "description": "ConsensusVersion indicates the consensus protocol version\nas of LastRound.",
+                  "type": "string"
+                },
+                "fee": {
+                  "description": "Fee is the suggested transaction fee\nFee is in units of micro-Algos per byte.\nFee may fall to zero but transactions must still have a fee of\nat least MinTxnFee for the current network protocol.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                },
+                "genesis-hash": {
+                  "description": "GenesisHash is the hash of the genesis block.",
+                  "format": "byte",
+                  "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+                  "type": "string"
+                },
+                "genesis-id": {
+                  "description": "GenesisID is an ID listed in the genesis block.",
+                  "type": "string"
+                },
+                "last-round": {
+                  "description": "LastRound indicates the last round seen",
+                  "type": "integer",
+                  "x-go-type": "basics.Round"
+                },
+                "min-fee": {
+                  "description": "The minimum transaction fee (not per byte) required for the txn to validate for the current network protocol.",
+                  "type": "integer",
+                  "x-go-type": "uint64"
+                }
+              },
+              "required": [
+                "consensus-version",
+                "fee",
+                "genesis-hash",
+                "genesis-id",
+                "last-round",
+                "min-fee"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "TransactionParams contains the parameters that help a client construct a new transaction."
+      },
+      "TransactionProofResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TransactionProof"
+            }
+          }
+        },
+        "description": "Proof of transaction in a block."
+      },
+      "VersionsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Version"
+            }
+          }
+        },
+        "description": "VersionsResponse is the response to 'GET /versions'"
+      }
+    },
+    "schemas": {
+      "Account": {
+        "description": "Account information at a given round.\n\nDefinition:\ndata/basics/userBalance.go : AccountData\n",
+        "properties": {
+          "address": {
+            "description": "the account public key",
+            "type": "string"
+          },
+          "amount": {
+            "description": "\\[algo\\] total number of MicroAlgos in the account",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "amount-without-pending-rewards": {
+            "description": "specifies the amount of MicroAlgos in the account, without the pending rewards.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "apps-local-state": {
+            "description": "\\[appl\\] applications local data stored in this account.\n\nNote the raw object uses `map[int] -> AppLocalState` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationLocalState"
+            },
+            "type": "array"
+          },
+          "apps-total-extra-pages": {
+            "description": "\\[teap\\] the sum of all extra application program pages for this account.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "apps-total-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "assets": {
+            "description": "\\[asset\\] assets held by this account.\n\nNote the raw object uses `map[int] -> AssetHolding` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/AssetHolding"
+            },
+            "type": "array"
+          },
+          "auth-addr": {
+            "description": "\\[spend\\] the address against which signing should be checked. If empty, the address of the current account is used. This field can be updated in any transaction by setting the RekeyTo field.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "created-apps": {
+            "description": "\\[appp\\] parameters of applications created by this account including app global data.\n\nNote: the raw account uses `map[int] -> AppParams` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            },
+            "type": "array"
+          },
+          "created-assets": {
+            "description": "\\[apar\\] parameters of assets created by this account.\n\nNote: the raw account uses `map[int] -> Asset` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            },
+            "type": "array"
+          },
+          "incentive-eligible": {
+            "description": "Whether or not the account can receive block incentives if its balance is in range at proposal time.",
+            "type": "boolean"
+          },
+          "last-heartbeat": {
+            "description": "The round in which this account last went online, or explicitly renewed their online status.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "last-proposed": {
+            "description": "The round in which this account last proposed the block.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "min-balance": {
+            "description": "MicroAlgo balance required by the account.\n\nThe requirement grows based on asset and application usage.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "participation": {
+            "$ref": "#/components/schemas/AccountParticipation"
+          },
+          "pending-rewards": {
+            "description": "amount of MicroAlgos of pending rewards in this account.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "reward-base": {
+            "description": "\\[ebase\\] used as part of the rewards computation. Only applicable to accounts which are participating.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "rewards": {
+            "description": "\\[ern\\] total rewards of MicroAlgos the account has received, including pending rewards.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "round": {
+            "description": "The round for which this information is relevant.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "sig-type": {
+            "description": "Indicates what type of signature is used by this account, must be one of:\n* sig\n* msig\n* lsig",
+            "enum": [
+              "sig",
+              "msig",
+              "lsig"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "description": "\\[onl\\] delegation status of the account's MicroAlgos\n* Offline - indicates that the associated account is delegated.\n*  Online  - indicates that the associated account used as part of the delegation pool.\n*   NotParticipating - indicates that the associated account is neither a delegator nor a delegate.",
+            "type": "string"
+          },
+          "total-apps-opted-in": {
+            "description": "The count of all applications that have been opted in, equivalent to the count of application local data (AppLocalState objects) stored in this account.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "total-assets-opted-in": {
+            "description": "The count of all assets that have been opted in, equivalent to the count of AssetHolding objects held by this account.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "total-box-bytes": {
+            "description": "\\[tbxb\\] The total number of bytes used by this account's app's box keys and values.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "total-boxes": {
+            "description": "\\[tbx\\] The number of existing boxes created by this account's app.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "total-created-apps": {
+            "description": "The count of all apps (AppParams objects) created by this account.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "total-created-assets": {
+            "description": "The count of all assets (AssetParams objects) created by this account.",
+            "format": "uint64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "address",
+          "amount",
+          "amount-without-pending-rewards",
+          "min-balance",
+          "pending-rewards",
+          "rewards",
+          "round",
+          "status",
+          "total-apps-opted-in",
+          "total-assets-opted-in",
+          "total-created-apps",
+          "total-created-assets"
+        ],
+        "type": "object"
+      },
+      "AccountApplicationResource": {
+        "description": "AccountApplicationResource describes the account's application resource (local state and params if the account is the creator) for a specific application ID.",
+        "properties": {
+          "app-local-state": {
+            "$ref": "#/components/schemas/ApplicationLocalState"
+          },
+          "created-at-round": {
+            "description": "Round when the account opted into or created the application.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "deleted": {
+            "description": "Whether the application has been deleted.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The application ID.",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "params": {
+            "$ref": "#/components/schemas/ApplicationParams"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "AccountAssetHolding": {
+        "description": "AccountAssetHolding describes the account's asset holding and asset parameters (if either exist) for a specific asset ID.",
+        "properties": {
+          "asset-holding": {
+            "$ref": "#/components/schemas/AssetHolding"
+          },
+          "asset-params": {
+            "$ref": "#/components/schemas/AssetParams"
+          }
+        },
+        "required": [
+          "asset-holding"
+        ],
+        "type": "object"
+      },
+      "AccountParticipation": {
+        "description": "AccountParticipation describes the parameters used by this account in consensus protocol.",
+        "properties": {
+          "selection-participation-key": {
+            "description": "\\[sel\\] Selection public key (if any) currently registered for this round.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "state-proof-key": {
+            "description": "\\[stprf\\] Root of the state proof key (if any)",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "vote-first-valid": {
+            "description": "\\[voteFst\\] First round for which this participation is valid.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "vote-key-dilution": {
+            "description": "\\[voteKD\\] Number of subkeys in each batch of participation keys.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "vote-last-valid": {
+            "description": "\\[voteLst\\] Last round for which this participation is valid.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "vote-participation-key": {
+            "description": "\\[vote\\] root participation public key (if any) currently registered for this round.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "selection-participation-key",
+          "vote-first-valid",
+          "vote-key-dilution",
+          "vote-last-valid",
+          "vote-participation-key"
+        ],
+        "type": "object"
+      },
+      "AccountStateDelta": {
+        "description": "Application state delta.",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "delta": {
+            "$ref": "#/components/schemas/StateDelta"
+          }
+        },
+        "required": [
+          "address",
+          "delta"
+        ],
+        "type": "object"
+      },
+      "AppCallLogs": {
+        "description": "The logged messages from an app call along with the app ID and outer transaction ID. Logs appear in the same order that they were emitted.",
+        "properties": {
+          "application-index": {
+            "description": "The application from which the logs were generated",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "logs": {
+            "description": "An array of logs",
+            "items": {
+              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "txId": {
+            "description": "The transaction ID of the outer app call that lead to these logs",
+            "type": "string"
+          }
+        },
+        "required": [
+          "application-index",
+          "logs",
+          "txId"
+        ],
+        "type": "object"
+      },
+      "Application": {
+        "description": "Application index and its parameters",
+        "properties": {
+          "id": {
+            "description": "\\[appidx\\] application index.",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "params": {
+            "$ref": "#/components/schemas/ApplicationParams"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "ApplicationInitialStates": {
+        "description": "An application's initial global/local/box states that were accessed during simulation.",
+        "properties": {
+          "app-boxes": {
+            "$ref": "#/components/schemas/ApplicationKVStorage"
+          },
+          "app-globals": {
+            "$ref": "#/components/schemas/ApplicationKVStorage"
+          },
+          "app-locals": {
+            "description": "An application's initial local states tied to different accounts.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationKVStorage"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Application index.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.AppIndex"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "ApplicationKVStorage": {
+        "description": "An application's global/local/box state.",
+        "properties": {
+          "account": {
+            "description": "The address of the account associated with the local state.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "kvs": {
+            "description": "Key-Value pairs representing application states.",
+            "items": {
+              "$ref": "#/components/schemas/AvmKeyValue"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "kvs"
+        ],
+        "type": "object"
+      },
+      "ApplicationLocalReference": {
+        "description": "References an account's local state for an application.",
+        "properties": {
+          "account": {
+            "description": "Address of the account with the local state.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "app": {
+            "description": "Application ID of the local state application.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.AppIndex"
+          }
+        },
+        "required": [
+          "account",
+          "app"
+        ],
+        "type": "object"
+      },
+      "ApplicationLocalState": {
+        "description": "Stores local state associated with an application.",
+        "properties": {
+          "id": {
+            "description": "The application which this local state is for.",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "key-value": {
+            "$ref": "#/components/schemas/TealKeyValueStore"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          }
+        },
+        "required": [
+          "id",
+          "schema"
+        ],
+        "type": "object"
+      },
+      "ApplicationParams": {
+        "description": "Stores the global information associated with an application.",
+        "properties": {
+          "approval-program": {
+            "description": "\\[approv\\] approval program.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "clear-state-program": {
+            "description": "\\[clearp\\] approval program.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "creator": {
+            "description": "The address that created this application. This is the address where the parameters and global state for this application can be found.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "extra-program-pages": {
+            "description": "\\[epp\\] the amount of extra program pages available to this app.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "family-box-access": {
+            "description": "\\[fba\\] if true, apps with the same creator may read and write this app's boxes",
+            "type": "boolean"
+          },
+          "foreign-box-reads": {
+            "description": "\\[fbr\\] if true, any app may read this app's boxes",
+            "type": "boolean"
+          },
+          "global-state": {
+            "$ref": "#/components/schemas/TealKeyValueStore"
+          },
+          "global-state-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "local-state-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "size-sponsor": {
+            "description": "\\[ss\\] the account responsible for extra pages and global state MBR",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "version": {
+            "description": "\\[v\\] the number of updates to the application programs",
+            "type": "integer",
+            "x-go-type": "uint64"
+          }
+        },
+        "required": [
+          "approval-program",
+          "clear-state-program",
+          "creator"
+        ],
+        "type": "object"
+      },
+      "ApplicationStateOperation": {
+        "description": "An operation against an application's global/local/box state.",
+        "properties": {
+          "account": {
+            "description": "For local state changes, the address of the account associated with the local state.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "app-state-type": {
+            "description": "Type of application state. Value `g` is **global state**, `l` is **local state**, `b` is **boxes**.",
+            "type": "string"
+          },
+          "key": {
+            "description": "The key (name) of the global/local/box state.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "new-value": {
+            "$ref": "#/components/schemas/AvmValue"
+          },
+          "operation": {
+            "description": "Operation type. Value `w` is **write**, `d` is **delete**.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app-state-type",
+          "key",
+          "operation"
+        ],
+        "type": "object"
+      },
+      "ApplicationStateSchema": {
+        "description": "Specifies maximums on the number of each type that may be stored.",
+        "properties": {
+          "num-byte-slice": {
+            "description": "\\[nbs\\] num of byte slices.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "num-uint": {
+            "description": "\\[nui\\] num of uints.",
+            "format": "uint64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "num-byte-slice",
+          "num-uint"
+        ],
+        "type": "object"
+      },
+      "Asset": {
+        "description": "Specifies both the unique identifier and the parameters for an asset",
+        "properties": {
+          "index": {
+            "description": "unique asset identifier",
+            "type": "integer",
+            "x-go-type": "basics.AssetIndex"
+          },
+          "params": {
+            "$ref": "#/components/schemas/AssetParams"
+          }
+        },
+        "required": [
+          "index"
+        ],
+        "type": "object"
+      },
+      "AssetHolding": {
+        "description": "Describes an asset held by an account.\n\nDefinition:\ndata/basics/userBalance.go : AssetHolding",
+        "properties": {
+          "amount": {
+            "description": "\\[a\\] number of units held.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "asset-id": {
+            "description": "Asset ID of the holding.",
+            "type": "integer",
+            "x-go-name": "AssetID",
+            "x-go-type": "basics.AssetIndex"
+          },
+          "is-frozen": {
+            "description": "\\[f\\] whether or not the holding is frozen.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "amount",
+          "asset-id",
+          "is-frozen"
+        ],
+        "type": "object"
+      },
+      "AssetHoldingReference": {
+        "description": "References an asset held by an account.",
+        "properties": {
+          "account": {
+            "description": "Address of the account holding the asset.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "asset": {
+            "description": "Asset ID of the holding.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.AssetIndex"
+          }
+        },
+        "required": [
+          "account",
+          "asset"
+        ],
+        "type": "object"
+      },
+      "AssetParams": {
+        "description": "AssetParams specifies the parameters for an asset.\n\n\\[apar\\] when part of an AssetConfig transaction.\n\nDefinition:\ndata/transactions/asset.go : AssetParams",
+        "properties": {
+          "clawback": {
+            "description": "\\[c\\] Address of account used to clawback holdings of this asset.  If empty, clawback is not permitted.",
+            "type": "string"
+          },
+          "creator": {
+            "description": "The address that created this asset. This is the address where the parameters for this asset can be found, and also the address where unwanted asset units can be sent in the worst case.",
+            "type": "string"
+          },
+          "decimals": {
+            "description": "\\[dc\\] The number of digits to use after the decimal point when displaying this asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths. If 2, the base unit of the asset is in hundredths, and so on. This value must be between 0 and 19 (inclusive).",
+            "format": "uint64",
+            "maximum": 19,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "default-frozen": {
+            "description": "\\[df\\] Whether holdings of this asset are frozen by default.",
+            "type": "boolean"
+          },
+          "freeze": {
+            "description": "\\[f\\] Address of account used to freeze holdings of this asset.  If empty, freezing is not permitted.",
+            "type": "string"
+          },
+          "manager": {
+            "description": "\\[m\\] Address of account used to manage the keys of this asset and to destroy it.",
+            "type": "string"
+          },
+          "metadata-hash": {
+            "description": "\\[am\\] A commitment to some unspecified asset metadata. The format of this metadata is up to the application.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "name": {
+            "description": "\\[an\\] Name of this asset, as supplied by the creator. Included only when the asset name is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "name-b64": {
+            "description": "Base64 encoded name of this asset, as supplied by the creator.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "reserve": {
+            "description": "\\[r\\] Address of account holding reserve (non-minted) units of this asset.",
+            "type": "string"
+          },
+          "total": {
+            "description": "\\[t\\] The total number of units of this asset.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "unit-name": {
+            "description": "\\[un\\] Name of a unit of this asset, as supplied by the creator. Included only when the name of a unit of this asset is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "unit-name-b64": {
+            "description": "Base64 encoded name of a unit of this asset, as supplied by the creator.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "url": {
+            "description": "\\[au\\] URL where more information about the asset can be retrieved. Included only when the URL is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "url-b64": {
+            "description": "Base64 encoded URL where more information about the asset can be retrieved.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "creator",
+          "decimals",
+          "total"
+        ],
+        "type": "object"
+      },
+      "AvmKeyValue": {
+        "description": "Represents an AVM key-value pair in an application store.",
+        "properties": {
+          "key": {
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AvmValue"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "AvmValue": {
+        "description": "Represents an AVM value.",
+        "properties": {
+          "bytes": {
+            "description": "bytes value.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "type": {
+            "description": "value type. Value `1` refers to **bytes**, value `2` refers to **uint64**",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "uint": {
+            "description": "uint value.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "Box": {
+        "description": "Box name and its content.",
+        "properties": {
+          "name": {
+            "description": "The box name, base64 encoded",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "round": {
+            "description": "The round for which this information is relevant",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "value": {
+            "description": "The box value, base64 encoded.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "round",
+          "value"
+        ],
+        "type": "object"
+      },
+      "BoxDescriptor": {
+        "description": "Box descriptor describes a Box.",
+        "properties": {
+          "name": {
+            "description": "Base64 encoded box name",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "value": {
+            "description": "Base64 encoded box value. Present only when the `values` query parameter is set to true.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "BoxReference": {
+        "description": "References a box of an application.",
+        "properties": {
+          "app": {
+            "description": "Application ID which this box belongs to",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "name": {
+            "description": "Base64 encoded box name",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app",
+          "name"
+        ],
+        "type": "object"
+      },
+      "BuildVersion": {
+        "properties": {
+          "branch": {
+            "type": "string"
+          },
+          "build_number": {
+            "type": "integer"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "commit_hash": {
+            "type": "string"
+          },
+          "major": {
+            "type": "integer"
+          },
+          "minor": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "branch",
+          "build_number",
+          "channel",
+          "commit_hash",
+          "major",
+          "minor"
+        ],
+        "title": "BuildVersion contains the current algod build version information.",
+        "type": "object"
+      },
+      "DebugSettingsProf": {
+        "description": "algod mutex and blocking profiling state.",
+        "properties": {
+          "block-rate": {
+            "description": "The rate of blocking events. The profiler aims to sample an average of one blocking event per rate nanoseconds spent blocked. To turn off profiling entirely, pass rate 0.",
+            "example": 1000,
+            "format": "uint64",
+            "type": "integer"
+          },
+          "mutex-rate": {
+            "description": "The rate of mutex events. On average 1/rate events are reported. To turn off profiling entirely, pass rate 0",
+            "example": 1000,
+            "format": "uint64",
+            "type": "integer"
+          }
+        },
+        "title": "algod mutex and blocking profiling state.",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "An error response with optional data field.",
+        "properties": {
+          "data": {
+            "properties": {},
+            "type": "object"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      },
+      "EvalDelta": {
+        "description": "Represents a TEAL value delta.",
+        "properties": {
+          "action": {
+            "description": "\\[at\\] delta action.",
+            "format": "uint64",
+            "type": "integer"
+          },
+          "bytes": {
+            "description": "\\[bs\\] bytes value.",
+            "type": "string"
+          },
+          "uint": {
+            "description": "\\[ui\\] uint value.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "EvalDeltaKeyValue": {
+        "description": "Key-value pairs for StateDelta.",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/EvalDelta"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "Genesis": {
+        "properties": {
+          "alloc": {
+            "items": {
+              "$ref": "#/components/schemas/GenesisAllocation"
+            },
+            "type": "array"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "devmode": {
+            "type": "boolean"
+          },
+          "fees": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "proto": {
+            "type": "string"
+          },
+          "rwd": {
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "alloc",
+          "fees",
+          "id",
+          "network",
+          "proto",
+          "rwd",
+          "timestamp"
+        ],
+        "title": "Genesis File in JSON",
+        "type": "object"
+      },
+      "GenesisAllocation": {
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "state": {
+            "properties": {
+              "algo": {
+                "format": "uint64",
+                "type": "integer"
+              },
+              "onl": {
+                "type": "integer"
+              },
+              "sel": {
+                "type": "string"
+              },
+              "stprf": {
+                "type": "string"
+              },
+              "vote": {
+                "type": "string"
+              },
+              "voteFst": {
+                "format": "uint64",
+                "type": "integer"
+              },
+              "voteKD": {
+                "format": "uint64",
+                "type": "integer"
+              },
+              "voteLst": {
+                "format": "uint64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "algo",
+              "onl"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "addr",
+          "comment",
+          "state"
+        ],
+        "title": "Allocations for Genesis File",
+        "type": "object"
+      },
+      "LedgerStateDelta": {
+        "description": "Ledger StateDelta object",
+        "type": "object",
+        "x-algorand-format": "StateDelta"
+      },
+      "LedgerStateDeltaForTransactionGroup": {
+        "description": "Contains a ledger delta for a single transaction group",
+        "properties": {
+          "Delta": {
+            "$ref": "#/components/schemas/LedgerStateDelta"
+          },
+          "Ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "Delta",
+          "Ids"
+        ],
+        "type": "object"
+      },
+      "LightBlockHeaderProof": {
+        "description": "Proof of membership and position of a light block header.",
+        "properties": {
+          "index": {
+            "description": "The index of the light block header in the vector commitment tree",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "proof": {
+            "description": "The encoded proof.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "treedepth": {
+            "description": "Represents the depth of the tree that is being proven, i.e. the number of edges from a leaf to the root.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "index",
+          "proof",
+          "treedepth"
+        ],
+        "type": "object"
+      },
+      "ParticipationKey": {
+        "description": "Represents a participation key used by the node.",
+        "properties": {
+          "address": {
+            "description": "Address the key was generated for.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "effective-first-valid": {
+            "description": "When registered, this is the first round it may be used.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.Round"
+          },
+          "effective-last-valid": {
+            "description": "When registered, this is the last round it may be used.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.Round"
+          },
+          "id": {
+            "description": "The key's ParticipationID.",
+            "type": "string"
+          },
+          "key": {
+            "$ref": "#/components/schemas/AccountParticipation"
+          },
+          "last-block-proposal": {
+            "description": "Round when this key was last used to propose a block.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "last-state-proof": {
+            "description": "Round when this key was last used to generate a state proof.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "last-vote": {
+            "description": "Round when this key was last used to vote.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          }
+        },
+        "required": [
+          "address",
+          "id",
+          "key"
+        ],
+        "type": "object"
+      },
+      "PeerStatus": {
+        "description": "The status of a connected peer in the P2P network",
+        "properties": {
+          "connection-type": {
+            "description": "Connection type",
+            "enum": [
+              "inbound",
+              "outbound"
+            ],
+            "type": "string"
+          },
+          "network-address": {
+            "description": "Network address of the peer",
+            "type": "string"
+          },
+          "network-type": {
+            "description": "Network type",
+            "enum": [
+              "p2p",
+              "ws"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "connection-type",
+          "network-address",
+          "network-type"
+        ],
+        "type": "object"
+      },
+      "PendingTransactionResponse": {
+        "description": "Details about a pending transaction. If the transaction was recently confirmed, includes confirmation details like the round and reward details.",
+        "properties": {
+          "application-index": {
+            "description": "The application index if the transaction was found and it created an application.",
+            "type": "integer",
+            "x-go-type": "basics.AppIndex"
+          },
+          "asset-closing-amount": {
+            "description": "The number of the asset's unit that were transferred to the close-to address.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "asset-index": {
+            "description": "The asset index if the transaction was found and it created an asset.",
+            "type": "integer",
+            "x-go-type": "basics.AssetIndex"
+          },
+          "close-rewards": {
+            "description": "Rewards in microalgos applied to the close remainder to account.",
+            "type": "integer"
+          },
+          "closing-amount": {
+            "description": "Closing amount for the transaction.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "confirmed-round": {
+            "description": "The round where this transaction was confirmed, if present.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "global-state-delta": {
+            "$ref": "#/components/schemas/StateDelta"
+          },
+          "inner-txns": {
+            "description": "Inner transactions produced by application execution.",
+            "items": {
+              "$ref": "#/components/schemas/PendingTransactionResponse"
+            },
+            "type": "array"
+          },
+          "local-state-delta": {
+            "description": "Local state key/value changes for the application being executed by this transaction.",
+            "items": {
+              "$ref": "#/components/schemas/AccountStateDelta"
+            },
+            "type": "array"
+          },
+          "logs": {
+            "description": "Logs for the application being executed by this transaction.",
+            "items": {
+              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "pool-error": {
+            "description": "Indicates that the transaction was kicked out of this node's transaction pool (and specifies why that happened).  An empty string indicates the transaction wasn't kicked out of this node's txpool due to an error.\n",
+            "type": "string"
+          },
+          "receiver-rewards": {
+            "description": "Rewards in microalgos applied to the receiver account.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "sender-rewards": {
+            "description": "Rewards in microalgos applied to the sender account.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "txn": {
+            "description": "The raw signed transaction.",
+            "properties": {},
+            "type": "object",
+            "x-algorand-format": "SignedTransaction"
+          }
+        },
+        "required": [
+          "pool-error",
+          "txn"
+        ],
+        "type": "object"
+      },
+      "ScratchChange": {
+        "description": "A write operation into a scratch slot.",
+        "properties": {
+          "new-value": {
+            "$ref": "#/components/schemas/AvmValue"
+          },
+          "slot": {
+            "description": "The scratch slot written.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "new-value",
+          "slot"
+        ],
+        "type": "object"
+      },
+      "SimulateInitialStates": {
+        "description": "Initial states of resources that were accessed during simulation.",
+        "properties": {
+          "app-initial-states": {
+            "description": "The initial states of accessed application before simulation. The order of this array is arbitrary.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationInitialStates"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SimulateRequest": {
+        "description": "Request type for simulation endpoint.",
+        "properties": {
+          "allow-empty-signatures": {
+            "description": "Allows transactions without signatures to be simulated as if they had correct signatures.",
+            "type": "boolean"
+          },
+          "allow-more-logging": {
+            "description": "Lifts limits on log opcode usage during simulation.",
+            "type": "boolean"
+          },
+          "allow-unnamed-resources": {
+            "description": "Allows access to unnamed resources during simulation.",
+            "type": "boolean"
+          },
+          "exec-trace-config": {
+            "$ref": "#/components/schemas/SimulateTraceConfig"
+          },
+          "extra-opcode-budget": {
+            "description": "Applies extra opcode budget during simulation for each transaction group.",
+            "type": "integer"
+          },
+          "fix-signers": {
+            "description": "If true, signers for transactions that are missing signatures will be fixed during evaluation.",
+            "type": "boolean"
+          },
+          "round": {
+            "description": "If provided, specifies the round preceding the simulation. State changes through this round will be used to run this simulation. Usually only the 4 most recent rounds will be available (controlled by the node config value MaxAcctLookback). If not specified, defaults to the latest available round.",
+            "type": "integer",
+            "x-go-type": "basics.Round"
+          },
+          "txn-groups": {
+            "description": "The transaction groups to simulate.",
+            "items": {
+              "$ref": "#/components/schemas/SimulateRequestTransactionGroup"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "txn-groups"
+        ],
+        "type": "object"
+      },
+      "SimulateRequestTransactionGroup": {
+        "description": "A transaction group to simulate.",
+        "properties": {
+          "txns": {
+            "description": "An atomic transaction group.",
+            "items": {
+              "description": "SignedTxn object. Must be canonically encoded.",
+              "format": "json",
+              "type": "string",
+              "x-algorand-format": "SignedTransaction"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "txns"
+        ],
+        "type": "object"
+      },
+      "SimulateTraceConfig": {
+        "description": "An object that configures simulation execution trace.",
+        "properties": {
+          "enable": {
+            "description": "A boolean option for opting in execution trace features simulation endpoint.",
+            "type": "boolean"
+          },
+          "scratch-change": {
+            "description": "A boolean option enabling returning scratch slot changes together with execution trace during simulation.",
+            "type": "boolean"
+          },
+          "stack-change": {
+            "description": "A boolean option enabling returning stack changes together with execution trace during simulation.",
+            "type": "boolean"
+          },
+          "state-change": {
+            "description": "A boolean option enabling returning application state changes (global, local, and box changes) with the execution trace during simulation.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "SimulateTransactionGroupResult": {
+        "description": "Simulation result for an atomic transaction group",
+        "properties": {
+          "app-budget-added": {
+            "description": "Total budget added during execution of app calls in the transaction group.",
+            "type": "integer"
+          },
+          "app-budget-consumed": {
+            "description": "Total budget consumed during execution of app calls in the transaction group.",
+            "type": "integer"
+          },
+          "failed-at": {
+            "description": "If present, indicates which transaction in this group caused the failure. This array represents the path to the failing transaction. Indexes are zero based, the first element indicates the top-level transaction, and successive elements indicate deeper inner transactions.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "failure-message": {
+            "description": "If present, indicates that the transaction group failed and specifies why that happened",
+            "type": "string"
+          },
+          "group-fees-paid": {
+            "description": "Total fees paid by the transaction group and all of its descendant inner transaction groups.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "group-usage": {
+            "description": "Fee usage for the transaction group, including all descendant inner transactions, in millionths of a basic transaction fee unit.",
+            "type": "integer",
+            "x-go-type": "basics.Micros"
+          },
+          "txn-results": {
+            "description": "Simulation result for individual transactions",
+            "items": {
+              "$ref": "#/components/schemas/SimulateTransactionResult"
+            },
+            "type": "array"
+          },
+          "unnamed-resources-accessed": {
+            "$ref": "#/components/schemas/SimulateUnnamedResourcesAccessed"
+          }
+        },
+        "required": [
+          "txn-results"
+        ],
+        "type": "object"
+      },
+      "SimulateTransactionResult": {
+        "description": "Simulation result for an individual transaction",
+        "properties": {
+          "app-budget-consumed": {
+            "description": "Budget used during execution of an app call transaction. This value includes budged used by inner app calls spawned by this transaction.",
+            "type": "integer"
+          },
+          "exec-trace": {
+            "$ref": "#/components/schemas/SimulationTransactionExecTrace"
+          },
+          "fees-paid": {
+            "description": "Total fees paid by this transaction and all of its descendant inner transactions.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "fixed-signer": {
+            "description": "The account that needed to sign this transaction when no signature was provided and the provided signer was incorrect.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "logic-sig-budget-consumed": {
+            "description": "Budget used during execution of a logic sig transaction.",
+            "type": "integer"
+          },
+          "txn-result": {
+            "$ref": "#/components/schemas/PendingTransactionResponse"
+          },
+          "unnamed-resources-accessed": {
+            "$ref": "#/components/schemas/SimulateUnnamedResourcesAccessed"
+          }
+        },
+        "required": [
+          "txn-result"
+        ],
+        "type": "object"
+      },
+      "SimulateUnnamedResourcesAccessed": {
+        "description": "These are resources that were accessed by this group that would normally have caused failure, but were allowed in simulation. Depending on where this object is in the response, the unnamed resources it contains may or may not qualify for group resource sharing. If this is a field in SimulateTransactionGroupResult, the resources do qualify, but if this is a field in SimulateTransactionResult, they do not qualify. In order to make this group valid for actual submission, resources that qualify for group sharing can be made available by any transaction of the group; otherwise, resources must be placed in the same transaction which accessed them.",
+        "properties": {
+          "accounts": {
+            "description": "The unnamed accounts that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "type": "array"
+          },
+          "app-locals": {
+            "description": "The unnamed application local states that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationLocalReference"
+            },
+            "type": "array"
+          },
+          "apps": {
+            "description": "The unnamed applications that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "type": "integer",
+              "x-algorand-format": "uint64",
+              "x-go-type": "basics.AppIndex"
+            },
+            "type": "array"
+          },
+          "asset-holdings": {
+            "description": "The unnamed asset holdings that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "$ref": "#/components/schemas/AssetHoldingReference"
+            },
+            "type": "array"
+          },
+          "assets": {
+            "description": "The unnamed assets that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "type": "integer",
+              "x-algorand-format": "uint64",
+              "x-go-type": "basics.AssetIndex"
+            },
+            "type": "array"
+          },
+          "boxes": {
+            "description": "The unnamed boxes that were referenced. The order of this array is arbitrary.",
+            "items": {
+              "$ref": "#/components/schemas/BoxReference"
+            },
+            "type": "array"
+          },
+          "extra-box-refs": {
+            "description": "The number of extra box references used to increase the IO budget. This is in addition to the references defined in the input transaction group and any referenced to unnamed boxes.",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SimulationEvalOverrides": {
+        "description": "The set of parameters and limits override during simulation. If this set of parameters is present, then evaluation parameters may differ from standard evaluation in certain ways.",
+        "properties": {
+          "allow-empty-signatures": {
+            "description": "If true, transactions without signatures are allowed and simulated as if they were properly signed.",
+            "type": "boolean"
+          },
+          "allow-unnamed-resources": {
+            "description": "If true, allows access to unnamed resources during simulation.",
+            "type": "boolean"
+          },
+          "extra-opcode-budget": {
+            "description": "The extra opcode budget added to each transaction group during simulation",
+            "type": "integer"
+          },
+          "fix-signers": {
+            "description": "If true, signers for transactions that are missing signatures will be fixed during evaluation.",
+            "type": "boolean"
+          },
+          "max-log-calls": {
+            "description": "The maximum log calls one can make during simulation",
+            "type": "integer"
+          },
+          "max-log-size": {
+            "description": "The maximum byte number to log during simulation",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SimulationOpcodeTraceUnit": {
+        "description": "The set of trace information and effect from evaluating a single opcode.",
+        "properties": {
+          "pc": {
+            "description": "The program counter of the current opcode being evaluated.",
+            "type": "integer"
+          },
+          "scratch-changes": {
+            "description": "The writes into scratch slots.",
+            "items": {
+              "$ref": "#/components/schemas/ScratchChange"
+            },
+            "type": "array"
+          },
+          "spawned-inners": {
+            "description": "The indexes of the traces for inner transactions spawned by this opcode, if any.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "stack-additions": {
+            "description": "The values added by this opcode to the stack.",
+            "items": {
+              "$ref": "#/components/schemas/AvmValue"
+            },
+            "type": "array"
+          },
+          "stack-pop-count": {
+            "description": "The number of deleted stack values by this opcode.",
+            "type": "integer"
+          },
+          "state-changes": {
+            "description": "The operations against the current application's states.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationStateOperation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "pc"
+        ],
+        "type": "object"
+      },
+      "SimulationTransactionExecTrace": {
+        "description": "The execution trace of calling an app or a logic sig, containing the inner app call trace in a recursive way.",
+        "properties": {
+          "approval-program-hash": {
+            "description": "SHA512_256 hash digest of the approval program executed in transaction.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "approval-program-trace": {
+            "description": "Program trace that contains a trace of opcode effects in an approval program.",
+            "items": {
+              "$ref": "#/components/schemas/SimulationOpcodeTraceUnit"
+            },
+            "type": "array"
+          },
+          "clear-state-program-hash": {
+            "description": "SHA512_256 hash digest of the clear state program executed in transaction.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "clear-state-program-trace": {
+            "description": "Program trace that contains a trace of opcode effects in a clear state program.",
+            "items": {
+              "$ref": "#/components/schemas/SimulationOpcodeTraceUnit"
+            },
+            "type": "array"
+          },
+          "clear-state-rollback": {
+            "description": "If true, indicates that the clear state program failed and any persistent state changes it produced should be reverted once the program exits.",
+            "type": "boolean"
+          },
+          "clear-state-rollback-error": {
+            "description": "The error message explaining why the clear state program failed. This field will only be populated if clear-state-rollback is true and the failure was due to an execution error.",
+            "type": "string"
+          },
+          "inner-trace": {
+            "description": "An array of SimulationTransactionExecTrace representing the execution trace of any inner transactions executed.",
+            "items": {
+              "$ref": "#/components/schemas/SimulationTransactionExecTrace"
+            },
+            "type": "array"
+          },
+          "logic-sig-hash": {
+            "description": "SHA512_256 hash digest of the logic sig executed in transaction.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "logic-sig-trace": {
+            "description": "Program trace that contains a trace of opcode effects in a logic sig.",
+            "items": {
+              "$ref": "#/components/schemas/SimulationOpcodeTraceUnit"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "StateDelta": {
+        "description": "Application state delta.",
+        "items": {
+          "$ref": "#/components/schemas/EvalDeltaKeyValue"
+        },
+        "type": "array"
+      },
+      "StateProof": {
+        "description": "Represents a state proof and its corresponding message",
+        "properties": {
+          "Message": {
+            "$ref": "#/components/schemas/StateProofMessage"
+          },
+          "StateProof": {
+            "description": "The encoded StateProof for the message.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "Message",
+          "StateProof"
+        ],
+        "type": "object"
+      },
+      "StateProofMessage": {
+        "description": "Represents the message that the state proofs are attesting to.",
+        "properties": {
+          "BlockHeadersCommitment": {
+            "description": "The vector commitment root on all light block headers within a state proof interval.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "FirstAttestedRound": {
+            "description": "The first round the message attests to.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.Round"
+          },
+          "LastAttestedRound": {
+            "description": "The last round the message attests to.",
+            "type": "integer",
+            "x-algorand-format": "uint64",
+            "x-go-type": "basics.Round"
+          },
+          "LnProvenWeight": {
+            "description": "An integer value representing the natural log of the proven weight with 16 bits of precision. This value would be used to verify the next state proof.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "VotersCommitment": {
+            "description": "The vector commitment root of the top N accounts to sign the next StateProof.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "BlockHeadersCommitment",
+          "FirstAttestedRound",
+          "LastAttestedRound",
+          "LnProvenWeight",
+          "VotersCommitment"
+        ],
+        "type": "object"
+      },
+      "TealKeyValue": {
+        "description": "Represents a key-value pair in an application store.",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/TealValue"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "TealKeyValueStore": {
+        "description": "Represents a key-value store for use in an application.",
+        "items": {
+          "$ref": "#/components/schemas/TealKeyValue"
+        },
+        "type": "array"
+      },
+      "TealValue": {
+        "description": "Represents a TEAL value.",
+        "properties": {
+          "bytes": {
+            "description": "\\[tb\\] bytes value.",
+            "type": "string"
+          },
+          "type": {
+            "description": "\\[tt\\] value type. Value `1` refers to **bytes**, value `2` refers to **uint**",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "uint": {
+            "description": "\\[ui\\] uint value.",
+            "format": "uint64",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "bytes",
+          "type",
+          "uint"
+        ],
+        "type": "object"
+      },
+      "TransactionProof": {
+        "description": "Proof of transaction in a block.",
+        "properties": {
+          "hashtype": {
+            "description": "The type of hash function used to create the proof, must be one of: \n* sha512_256 \n* sha256",
+            "enum": [
+              "sha512_256",
+              "sha256"
+            ],
+            "type": "string"
+          },
+          "idx": {
+            "description": "Index of the transaction in the block's payset.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          },
+          "proof": {
+            "description": "Proof of transaction membership.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "stibhash": {
+            "description": "Hash of SignedTxnInBlock for verifying proof.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "treedepth": {
+            "description": "Represents the depth of the tree that is being proven, i.e. the number of edges from a leaf to the root.",
+            "type": "integer",
+            "x-go-type": "uint64"
+          }
+        },
+        "required": [
+          "hashtype",
+          "idx",
+          "proof",
+          "stibhash",
+          "treedepth"
+        ],
+        "type": "object"
+      },
+      "Version": {
+        "description": "algod version information.",
+        "properties": {
+          "build": {
+            "$ref": "#/components/schemas/BuildVersion"
+          },
+          "genesis_hash_b64": {
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "genesis_id": {
+            "type": "string"
+          },
+          "versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "build",
+          "genesis_hash_b64",
+          "genesis_id",
+          "versions"
+        ],
+        "title": "Version contains the current algod version.",
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "description": "Generated header parameter. This token can be generated using the Goal command line tool. Example value ='b7e384d0317b8050ce45900a94a1931e28540e1f69b2d242b424659c341b4697'",
+        "in": "header",
+        "name": "X-Algo-API-Token",
+        "type": "apiKey"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "contact@algorand.com",
+      "name": "algorand",
+      "url": "https://www.algorand.com/get-in-touch/contact"
+    },
+    "description": "`algod` is the Algorand node daemon. Its REST API is how you submit and\nsimulate transactions, read accounts, applications, assets and boxes, fetch\nblocks and ledger state, and check node and network status.\n\nEvery endpoint is listed in the sidebar under **algod** → the tag groups, one page per\noperation.\n\nSpec downloads (OAS2 and OAS3) and ready-to-run Scalar, Swagger and Postman\ncollections are on the [REST API overview](/reference/rest-api/overview).",
+    "title": "Algod REST API",
+    "version": "0.0.1"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/debug/settings/config": {
+      "get": {
+        "description": "Returns the merged (defaults + overrides) config file in json.",
+        "operationId": "GetConfig",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The merged config file in json."
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets the merged config file.",
+        "tags": [
+          "private"
+        ]
+      }
+    },
+    "/debug/settings/pprof": {
+      "get": {
+        "description": "Retrieves the current settings for blocking and mutex profiles",
+        "operationId": "GetDebugSettingsProf",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugSettingsProf"
+                }
+              }
+            },
+            "description": "DebugPprof is the response to the /debug/extra/pprof endpoint"
+          }
+        },
+        "tags": [
+          "private"
+        ]
+      },
+      "put": {
+        "description": "Enables blocking and mutex profiles, and returns the old settings",
+        "operationId": "PutDebugSettingsProf",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DebugSettingsProf"
+                }
+              }
+            },
+            "description": "DebugPprof is the response to the /debug/extra/pprof endpoint"
+          }
+        },
+        "tags": [
+          "private"
+        ]
+      }
+    },
+    "/genesis": {
+      "get": {
+        "description": "Returns the entire genesis file in json.",
+        "operationId": "GetGenesis",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Genesis"
+                }
+              }
+            },
+            "description": "The genesis file in json."
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets the genesis information.",
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "HealthCheck",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "OK."
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns OK if healthy.",
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "Metrics",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "text with \\#-comments and key:value lines"
+          },
+          "404": {
+            "content": {},
+            "description": "metrics were compiled out"
+          }
+        },
+        "summary": "Return metrics about algod functioning.",
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    },
+    "/ready": {
+      "get": {
+        "operationId": "GetReady",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "OK."
+          },
+          "500": {
+            "content": {},
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {},
+            "description": "Node not ready yet"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns OK if healthy and fully caught up.",
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    },
+    "/swagger.json": {
+      "get": {
+        "description": "Returns the entire swagger spec in json.",
+        "operationId": "SwaggerJSON",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "The current swagger spec"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets the current swagger spec.",
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    },
+    "/v2/accounts/{address}": {
+      "get": {
+        "description": "Given a specific account public key, this call returns the account's status, balance and spendable amounts",
+        "operationId": "AccountInformation",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "Exclude additional items from the account. Use `all` to exclude asset holdings, application local state, created asset parameters, and created application parameters. Use `created-apps-params` to exclude only the parameters of created applications (returns only application IDs). Use `created-assets-params` to exclude only the parameters of created assets (returns only asset IDs). Multiple values can be comma-separated (e.g., `created-apps-params,created-assets-params`). Note: `all` and `none` cannot be combined with other values. Defaults to `none`.",
+            "explode": false,
+            "in": "query",
+            "name": "exclude",
+            "schema": {
+              "items": {
+                "enum": [
+                  "all",
+                  "none",
+                  "created-apps-params",
+                  "created-assets-params"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            },
+            "description": "AccountResponse wraps the Account type in a response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get account information.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/accounts/{address}/applications": {
+      "get": {
+        "description": "Lookup an account's application holdings (local state and params if the account is the creator).",
+        "operationId": "AccountApplicationsInformation",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "Maximum number of results to return.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include additional items in the response. Use `params` to include full application parameters (global state, schema, etc.). Multiple values can be comma-separated. Defaults to returning only application IDs and local state.",
+            "explode": false,
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "items": {
+                "enum": [
+                  "params"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "application-resources": {
+                      "items": {
+                        "$ref": "#/components/schemas/AccountApplicationResource"
+                      },
+                      "type": "array"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter. The next token is the next application ID to use as the pagination cursor.",
+                      "type": "string"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "AccountApplicationsInformationResponse contains a list of application resources for an account."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Malformed address"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a list of applications held by an account.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/accounts/{address}/applications/{application-id}": {
+      "get": {
+        "description": "Given a specific account public key and application ID, this call returns the account's application local state and global state (AppLocalState and AppParams, if either exists). Global state will only be returned if the provided address is the application's creator.",
+        "operationId": "AccountApplicationInformation",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "An application identifier.",
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AppIndex"
+            },
+            "x-go-type": "basics.AppIndex"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "app-local-state": {
+                      "$ref": "#/components/schemas/ApplicationLocalState"
+                    },
+                    "created-app": {
+                      "$ref": "#/components/schemas/ApplicationParams"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "properties": {
+                    "app-local-state": {
+                      "$ref": "#/components/schemas/ApplicationLocalState"
+                    },
+                    "created-app": {
+                      "$ref": "#/components/schemas/ApplicationParams"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "AccountApplicationResponse describes the account's application local state and global state (AppLocalState and AppParams, if either exists) for a specific application ID. Global state will only be returned if the provided address is the application's creator."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Malformed address or application ID"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get account information about a given app.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/accounts/{address}/assets": {
+      "get": {
+        "description": "Lookup an account's asset holdings.",
+        "operationId": "AccountAssetsInformation",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "Maximum number of results to return.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "asset-holdings": {
+                      "items": {
+                        "$ref": "#/components/schemas/AccountAssetHolding"
+                      },
+                      "type": "array"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "AccountAssetsInformationResponse contains a list of assets held by an account."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Malformed address"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a list of assets held by an account, inclusive of asset params.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/accounts/{address}/assets/{asset-id}": {
+      "get": {
+        "description": "Given a specific account public key and asset ID, this call returns the account's asset holding and asset parameters (if either exist). Asset parameters will only be returned if the provided address is the asset's creator.",
+        "operationId": "AccountAssetInformation",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "An asset identifier.",
+            "in": "path",
+            "name": "asset-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AssetIndex"
+            },
+            "x-go-type": "basics.AssetIndex"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "asset-holding": {
+                      "$ref": "#/components/schemas/AssetHolding"
+                    },
+                    "created-asset": {
+                      "$ref": "#/components/schemas/AssetParams"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "properties": {
+                    "asset-holding": {
+                      "$ref": "#/components/schemas/AssetHolding"
+                    },
+                    "created-asset": {
+                      "$ref": "#/components/schemas/AssetParams"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "AccountAssetResponse describes the account's asset holding and asset parameters (if either exist) for a specific asset ID. Asset parameters will only be returned if the provided address is the asset's creator."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Malformed address or asset ID"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get account information about a given asset.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/accounts/{address}/transactions/pending": {
+      "get": {
+        "description": "Get the list of pending transactions by address, sorted by priority, in decreasing order, truncated at the end at MAX. If MAX = 0, returns all pending transactions.",
+        "operationId": "GetPendingTransactionsByAddress",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "Truncated number of transactions to display. If max=0, returns all pending txns.",
+            "in": "query",
+            "name": "max",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "PendingTransactions is an array of signed transactions exactly as they were submitted.",
+                  "properties": {
+                    "top-transactions": {
+                      "description": "An array of signed transaction objects.",
+                      "items": {
+                        "properties": {},
+                        "type": "object",
+                        "x-algorand-format": "SignedTransaction"
+                      },
+                      "type": "array"
+                    },
+                    "total-transactions": {
+                      "description": "Total number of transactions in the pool.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "top-transactions",
+                    "total-transactions"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "description": "PendingTransactions is an array of signed transactions exactly as they were submitted.",
+                  "properties": {
+                    "top-transactions": {
+                      "description": "An array of signed transaction objects.",
+                      "items": {
+                        "properties": {},
+                        "type": "object",
+                        "x-algorand-format": "SignedTransaction"
+                      },
+                      "type": "array"
+                    },
+                    "total-transactions": {
+                      "description": "Total number of transactions in the pool.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "top-transactions",
+                    "total-transactions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A potentially truncated list of transactions currently in the node's transaction pool. You can compute whether or not the list is truncated if the number of elements in the **top-transactions** array is fewer than **total-transactions**."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Max must be a non-negative integer"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a list of unconfirmed transactions currently in the transaction pool by address.",
+        "tags": [
+          "public",
+          "participating"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}": {
+      "get": {
+        "description": "Given a application ID, it returns application information including creator, approval and clear programs, global and local schemas, and global state.",
+        "operationId": "GetApplicationByID",
+        "parameters": [
+          {
+            "description": "An application identifier.",
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AppIndex"
+            },
+            "x-go-type": "basics.AppIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Application"
+                }
+              }
+            },
+            "description": "Application information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Application Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get application information.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}/box": {
+      "get": {
+        "description": "Given an application ID and box name, it returns the round, box name, and value (each base64 encoded). Box names must be in the goal app call arg encoding form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, use the form 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.",
+        "operationId": "GetApplicationBoxByName",
+        "parameters": [
+          {
+            "description": "An application identifier.",
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AppIndex"
+            },
+            "x-go-type": "basics.AppIndex"
+          },
+          {
+            "description": "A box name, in the goal app call arg form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, use the form 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Box"
+                }
+              }
+            },
+            "description": "Box information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Box Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get box information for a given application.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}/boxes": {
+      "get": {
+        "description": "Given an application ID, return all box names. No particular ordering is guaranteed. Request fails when client or server-side configured limits prevent returning all box names.\n\nPagination mode is enabled when any of the following parameters are provided: limit, next, prefix, include, or round. In pagination mode box values can be requested and results are returned in sorted order.\n\nTo paginate: use the next-token from a previous response as the next parameter in the following request. Pin the round parameter to the round value from the first page's response to ensure consistent results across pages. The server enforces a per-response byte limit, so fewer results than limit may be returned even when more exist; the presence of next-token is the only reliable signal that more data is available.",
+        "operationId": "GetApplicationBoxes",
+        "parameters": [
+          {
+            "description": "An application identifier.",
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AppIndex"
+            },
+            "x-go-type": "basics.AppIndex"
+          },
+          {
+            "description": "Max number of box names to return. If max is not set, or max == 0, returns all box-names.",
+            "in": "query",
+            "name": "max",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "Maximum number of boxes to return per page.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "A box name, in the goal app call arg form 'encoding:value', representing the earliest box name to include in results. Use the next-token from a previous response.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "A box name prefix, in the goal app call arg form 'encoding:value', to filter results by. Only boxes whose names start with this prefix will be returned.",
+            "in": "query",
+            "name": "prefix",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include additional items in the response. Use `values` to include box values. Multiple values can be comma-separated.",
+            "explode": false,
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "items": {
+                "enum": [
+                  "values"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Return box data from the given round. The round must be within the node's available range.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "format": "uint64",
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "boxes": {
+                      "items": {
+                        "$ref": "#/components/schemas/BoxDescriptor"
+                      },
+                      "type": "array"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter. The next token is the box name to use as the pagination cursor, encoded in the goal app call arg form.",
+                      "type": "string"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "boxes"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Boxes of an application"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get all box names for a given application.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/assets/{asset-id}": {
+      "get": {
+        "description": "Given a asset ID, it returns asset information including creator, name, total supply and special addresses.",
+        "operationId": "GetAssetByID",
+        "parameters": [
+          {
+            "description": "An asset identifier.",
+            "in": "path",
+            "name": "asset-id",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.AssetIndex"
+            },
+            "x-go-type": "basics.AssetIndex"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            },
+            "description": "Asset information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Application Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get asset information.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}": {
+      "get": {
+        "operationId": "GetBlock",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          },
+          {
+            "description": "If true, only the block header (exclusive of payset or certificate) may be included in response.",
+            "in": "query",
+            "name": "header-only",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "block": {
+                      "description": "Block header data.",
+                      "properties": {},
+                      "type": "object",
+                      "x-algorand-format": "BlockHeader"
+                    },
+                    "cert": {
+                      "description": "Optional certificate object. This is only included when the format is set to message pack.",
+                      "properties": {},
+                      "type": "object",
+                      "x-algorand-format": "BlockCertificate"
+                    }
+                  },
+                  "required": [
+                    "block"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "properties": {
+                    "block": {
+                      "description": "Block header data.",
+                      "properties": {},
+                      "type": "object",
+                      "x-algorand-format": "BlockHeader"
+                    },
+                    "cert": {
+                      "description": "Optional certificate object. This is only included when the format is set to message pack.",
+                      "properties": {},
+                      "type": "object",
+                      "x-algorand-format": "BlockCertificate"
+                    }
+                  },
+                  "required": [
+                    "block"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Encoded block object."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Non integer number"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "None existing block "
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get the block for the given round.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}/hash": {
+      "get": {
+        "operationId": "GetBlockHash",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blockHash": {
+                      "description": "Block header hash.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "blockHash"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Hash of a block header."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Non integer number"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "None existing block "
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get the block hash for the block on the given round.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}/lightheader/proof": {
+      "get": {
+        "operationId": "GetLightBlockHeaderProof",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LightBlockHeaderProof"
+                }
+              }
+            },
+            "description": "Proof of a light block header."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Could not create proof since some data is missing"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "timed out on request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets a proof for a given light block header inside a state proof commitment",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}/logs": {
+      "get": {
+        "description": "Get all of the logs from outer and inner app calls in the given round",
+        "operationId": "GetBlockLogs",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "logs": {
+                      "items": {
+                        "$ref": "#/components/schemas/AppCallLogs"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "logs"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "All logs emitted in the given round. Each app call, whether top-level or inner, that contains logs results in a separate AppCallLogs object. Therefore there may be multiple AppCallLogs with the same application ID and outer transaction ID in the event of multiple inner app calls to the same app. App calls with no logs are not included in the response. AppCallLogs are returned in the same order that their corresponding app call appeared in the block (pre-order traversal of inner app calls)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Non integer number"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Nonexistent block "
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          }
+        },
+        "summary": "Get all of the logs from outer and inner app calls in the given round",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}/transactions/{txid}/proof": {
+      "get": {
+        "operationId": "GetTransactionProof",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          },
+          {
+            "description": "The transaction ID for which to generate a proof.",
+            "in": "path",
+            "name": "txid",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]+",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The type of hash function used to create the proof, must be one of: \n* sha512_256 \n* sha256",
+            "in": "query",
+            "name": "hashtype",
+            "schema": {
+              "enum": [
+                "sha512_256",
+                "sha256"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionProof"
+                }
+              }
+            },
+            "description": "Proof of transaction in a block."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Malformed round number or transaction ID"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Non-existent block or transaction"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal error, including protocol not supporting proofs."
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown error"
+          }
+        },
+        "summary": "Get a proof for a transaction in a block.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/blocks/{round}/txids": {
+      "get": {
+        "operationId": "GetBlockTxids",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blockTxids": {
+                      "description": "Block transaction IDs.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "blockTxids"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Top level transaction IDs in a block."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Non integer number"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Non existing block"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get the top level transaction IDs for the block on the given round.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/catchup/{catchpoint}": {
+      "delete": {
+        "description": "Given a catchpoint, it aborts catching up to this catchpoint",
+        "operationId": "AbortCatchup",
+        "parameters": [
+          {
+            "description": "A catch point",
+            "in": "path",
+            "name": "catchpoint",
+            "required": true,
+            "schema": {
+              "format": "catchpoint",
+              "pattern": "[0-9]{1,10}#[A-Z0-9]{1,53}",
+              "type": "string",
+              "x-algorand-format": "Catchpoint String"
+            },
+            "x-algorand-format": "Catchpoint String"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "An catchpoint abort response.",
+                  "properties": {
+                    "catchup-message": {
+                      "description": "Catchup abort response string",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "catchup-message"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Aborts a catchpoint catchup.",
+        "tags": [
+          "private",
+          "nonparticipating"
+        ]
+      },
+      "post": {
+        "description": "Given a catchpoint, it starts catching up to this catchpoint",
+        "operationId": "StartCatchup",
+        "parameters": [
+          {
+            "description": "A catch point",
+            "in": "path",
+            "name": "catchpoint",
+            "required": true,
+            "schema": {
+              "format": "catchpoint",
+              "pattern": "[0-9]{1,10}#[A-Z0-9]{1,53}",
+              "type": "string",
+              "x-algorand-format": "Catchpoint String"
+            },
+            "x-algorand-format": "Catchpoint String"
+          },
+          {
+            "description": "Specify the minimum number of blocks which the ledger must be advanced by in order to start the catchup. This is useful for simplifying tools which support fast catchup, they can run the catchup unconditionally and the node will skip the catchup if it is not needed.",
+            "in": "query",
+            "name": "min",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "An catchpoint start response.",
+                  "properties": {
+                    "catchup-message": {
+                      "description": "Catchup start response string",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "catchup-message"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "An catchpoint start response.",
+                  "properties": {
+                    "catchup-message": {
+                      "description": "Catchup start response string",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "catchup-message"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Request Timeout"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Starts a catchpoint catchup.",
+        "tags": [
+          "private",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/deltas/txn/group/{id}": {
+      "get": {
+        "description": "Get a ledger delta for a given transaction group.",
+        "operationId": "GetLedgerStateDeltaForTransactionGroup",
+        "parameters": [
+          {
+            "description": "A transaction ID, or transaction group ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]+",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerStateDelta"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerStateDelta"
+                }
+              }
+            },
+            "description": "Response containing a ledger state delta for a single transaction group."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Could not find a delta for transaction ID or group ID"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "timed out on request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Implemented"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a LedgerStateDelta object for a given transaction group",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/deltas/{round}": {
+      "get": {
+        "description": "Get ledger deltas for a round.",
+        "operationId": "GetLedgerStateDelta",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerStateDelta"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerStateDelta"
+                }
+              }
+            },
+            "description": "Contains ledger deltas"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Could not find a delta for round"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "timed out on request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a LedgerStateDelta object for a given round",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/deltas/{round}/txn/group": {
+      "get": {
+        "description": "Get ledger deltas for transaction groups in a given round.",
+        "operationId": "GetTransactionGroupLedgerStateDeltasForRound",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Deltas": {
+                      "items": {
+                        "$ref": "#/components/schemas/LedgerStateDeltaForTransactionGroup"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "Deltas"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "properties": {
+                    "Deltas": {
+                      "items": {
+                        "$ref": "#/components/schemas/LedgerStateDeltaForTransactionGroup"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "Deltas"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response containing all ledger state deltas for transaction groups, with their associated Ids, in a single round."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Could not find deltas for round"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "timed out on request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not Implemented"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get LedgerStateDelta objects for all transaction groups in a given round",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/devmode/blocks/offset": {
+      "get": {
+        "description": "Gets the current timestamp offset.",
+        "operationId": "GetBlockTimeStampOffset",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "offset": {
+                      "description": "Timestamp offset in seconds.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    }
+                  },
+                  "required": [
+                    "offset"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response containing the timestamp offset in seconds"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "TimeStamp offset not set."
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns the timestamp offset. Timestamp offsets can only be set in dev mode.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/devmode/blocks/offset/{offset}": {
+      "post": {
+        "description": "Sets the timestamp offset (seconds) for blocks in dev mode. Providing an offset of 0 will unset this value and try to use the real clock for the timestamp.",
+        "operationId": "SetBlockTimeStampOffset",
+        "parameters": [
+          {
+            "description": "The timestamp offset for blocks in dev mode.",
+            "in": "path",
+            "name": "offset",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Cannot set timestamp offset to a negative integer."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Given a timestamp offset in seconds, adds the offset to every subsequent block header's timestamp.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/experimental": {
+      "get": {
+        "operationId": "ExperimentalCheck",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Experimental API enabled"
+          },
+          "404": {
+            "content": {},
+            "description": "Experimental API not enabled"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns OK if experimental API is enabled.",
+        "tags": [
+          "public",
+          "experimental"
+        ]
+      }
+    },
+    "/v2/ledger/supply": {
+      "get": {
+        "operationId": "GetSupply",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Supply represents the current supply of MicroAlgos in the system",
+                  "properties": {
+                    "current_round": {
+                      "description": "Round",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "online-money": {
+                      "description": "Total stake held by accounts with status Online at current_round, including those whose participation keys have expired but have not yet been marked offline.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "online-stake": {
+                      "description": "Online stake used by agreement to vote for current_round, excluding accounts whose participation keys have expired.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "total-money": {
+                      "description": "TotalMoney",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    }
+                  },
+                  "required": [
+                    "current_round",
+                    "online-money",
+                    "online-stake",
+                    "total-money"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Supply represents the current supply of MicroAlgos in the system."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get the current supply reported by the ledger.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/ledger/sync": {
+      "delete": {
+        "description": "Unset the ledger sync round.",
+        "operationId": "UnsetSyncRound",
+        "responses": {
+          "200": {
+            "content": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sync round not set."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Removes minimum sync round restriction from the ledger.",
+        "tags": [
+          "public",
+          "data"
+        ]
+      },
+      "get": {
+        "description": "Gets the minimum sync round for the ledger.",
+        "operationId": "GetSyncRound",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "round": {
+                      "description": "The minimum sync round for the ledger.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response containing the ledger's minimum sync round"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Sync round not set."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns the minimum sync round the ledger is keeping in cache.",
+        "tags": [
+          "public",
+          "data"
+        ]
+      }
+    },
+    "/v2/ledger/sync/{round}": {
+      "post": {
+        "description": "Sets the minimum sync round on the ledger.",
+        "operationId": "SetSyncRound",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Can not set sync round to an earlier round than the current round."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Given a round, tells the ledger to keep that round in its cache.",
+        "tags": [
+          "public",
+          "data"
+        ]
+      }
+    },
+    "/v2/node/peers": {
+      "get": {
+        "description": "Get information about connected peers.",
+        "operationId": "GetPeers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "Peers": {
+                      "items": {
+                        "$ref": "#/components/schemas/PeerStatus"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "Peers"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response containing the network peers of the node"
+          }
+        },
+        "tags": [
+          "private"
+        ]
+      }
+    },
+    "/v2/node/shutdown": {
+      "post": {
+        "description": "Special management endpoint to shutdown the node. Optionally provide a timeout parameter to indicate that the node should begin shutting down after a number of seconds.",
+        "operationId": "ShutdownNode2",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "timeout",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "private",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/participation": {
+      "get": {
+        "description": "Return a list of participation keys",
+        "operationId": "GetParticipationKeys",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ParticipationKey"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "A list of participation keys"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Participation Key Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Return a list of participation keys",
+        "tags": [
+          "private",
+          "participating"
+        ]
+      },
+      "post": {
+        "operationId": "AddParticipationKey",
+        "requestBody": {
+          "content": {
+            "application/msgpack": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "The participation key to add to the node",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "partId": {
+                      "description": "encoding of the participation ID.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "partId"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Participation ID of the submission"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Participation Key Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Add a participation key to the node",
+        "tags": [
+          "private",
+          "participating"
+        ],
+        "x-codegen-request-body-name": "participationkey"
+      }
+    },
+    "/v2/participation/generate/{address}": {
+      "post": {
+        "operationId": "GenerateParticipationKeys",
+        "parameters": [
+          {
+            "description": "An account public key.",
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]{58}",
+              "type": "string",
+              "x-go-type": "basics.Address"
+            },
+            "x-go-type": "basics.Address"
+          },
+          {
+            "description": "Key dilution for two-level participation keys (defaults to sqrt of validity window).",
+            "in": "query",
+            "name": "dilution",
+            "schema": {
+              "format": "uint64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "First round for participation key.",
+            "in": "query",
+            "name": "first",
+            "required": true,
+            "schema": {
+              "format": "uint64",
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          },
+          {
+            "description": "Last round for participation key.",
+            "in": "query",
+            "name": "last",
+            "required": true,
+            "schema": {
+              "format": "uint64",
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "An empty JSON object is returned if the generation process was started. Currently no status is available."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Generate and install participation keys to the node.",
+        "tags": [
+          "private",
+          "participating"
+        ]
+      }
+    },
+    "/v2/participation/{participation-id}": {
+      "delete": {
+        "description": "Delete a given participation key by ID",
+        "operationId": "DeleteParticipationKeyByID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "participation-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Participation key got deleted by ID"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Participation Key Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Delete a given participation key by ID",
+        "tags": [
+          "private",
+          "participating"
+        ]
+      },
+      "get": {
+        "description": "Given a participation ID, return information about that participation key",
+        "operationId": "GetParticipationKeyByID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "participation-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParticipationKey"
+                }
+              }
+            },
+            "description": "A detailed description of a participation ID"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Participation Key Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get participation key info given a participation ID",
+        "tags": [
+          "private",
+          "participating"
+        ]
+      },
+      "post": {
+        "description": "Given a participation ID, append state proof keys to a particular set of participation keys",
+        "operationId": "AppendKeys",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "participation-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/msgpack": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "The state proof keys to add to an existing participation ID",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParticipationKey"
+                }
+              }
+            },
+            "description": "A detailed description of a participation ID"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Participation Key Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Append state proof keys to a participation key",
+        "tags": [
+          "private",
+          "participating"
+        ],
+        "x-codegen-request-body-name": "keymap"
+      }
+    },
+    "/v2/shutdown": {
+      "post": {
+        "deprecated": true,
+        "description": "Special management endpoint to shutdown the node. Optionally provide a timeout parameter to indicate that the node should begin shutting down after a number of seconds. This endpoint is deprecated, use `POST /v2/node/shutdown` instead",
+        "operationId": "ShutdownNode",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "timeout",
+            "schema": {
+              "default": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "private",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/stateproofs/{round}": {
+      "get": {
+        "operationId": "GetStateProof",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateProof"
+                }
+              }
+            },
+            "description": "StateProofResponse wraps the StateProof type in a response."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Could not find a state proof that covers a given round"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "timed out on request"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a state proof that covers a given round",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/status": {
+      "get": {
+        "operationId": "GetStatus",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "NodeStatus contains the information about a node status",
+                  "properties": {
+                    "catchpoint": {
+                      "description": "The current catchpoint that is being caught up to",
+                      "type": "string"
+                    },
+                    "catchpoint-acquired-blocks": {
+                      "description": "The number of blocks that have already been obtained by the node as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-processed-accounts": {
+                      "description": "The number of accounts from the current catchpoint that have been processed so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-processed-kvs": {
+                      "description": "The number of key-values (KVs) from the current catchpoint that have been processed so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-accounts": {
+                      "description": "The total number of accounts included in the current catchpoint",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-blocks": {
+                      "description": "The total number of blocks that are required to complete the current catchpoint catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-kvs": {
+                      "description": "The total number of key-values (KVs) included in the current catchpoint",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-verified-accounts": {
+                      "description": "The number of accounts from the current catchpoint that have been verified so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-verified-kvs": {
+                      "description": "The number of key-values (KVs) from the current catchpoint that have been verified so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchup-time": {
+                      "description": "CatchupTime in nanoseconds",
+                      "type": "integer",
+                      "x-go-type": "int64"
+                    },
+                    "last-catchpoint": {
+                      "description": "The last catchpoint seen by the node",
+                      "type": "string"
+                    },
+                    "last-round": {
+                      "description": "LastRound indicates the last round seen",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "last-version": {
+                      "description": "LastVersion indicates the last consensus version supported",
+                      "type": "string"
+                    },
+                    "next-version": {
+                      "description": "NextVersion of consensus protocol to use",
+                      "type": "string"
+                    },
+                    "next-version-round": {
+                      "description": "NextVersionRound is the round at which the next consensus version will apply",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "next-version-supported": {
+                      "description": "NextVersionSupported indicates whether the next consensus version is supported by this node",
+                      "type": "boolean"
+                    },
+                    "stopped-at-unsupported-round": {
+                      "description": "StoppedAtUnsupportedRound indicates that the node does not support the new rounds and has stopped making progress",
+                      "type": "boolean"
+                    },
+                    "time-since-last-round": {
+                      "description": "TimeSinceLastRound in nanoseconds",
+                      "type": "integer",
+                      "x-go-type": "int64"
+                    },
+                    "upgrade-delay": {
+                      "description": "Upgrade delay",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-next-protocol-vote-before": {
+                      "description": "Next protocol round",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-no-votes": {
+                      "description": "No votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-node-vote": {
+                      "description": "This node's upgrade vote",
+                      "type": "boolean"
+                    },
+                    "upgrade-vote-rounds": {
+                      "description": "Total voting rounds for current upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-votes": {
+                      "description": "Total votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-votes-required": {
+                      "description": "Yes votes required for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-yes-votes": {
+                      "description": "Yes votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "catchup-time",
+                    "last-round",
+                    "last-version",
+                    "next-version",
+                    "next-version-round",
+                    "next-version-supported",
+                    "stopped-at-unsupported-round",
+                    "time-since-last-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets the current node status.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/status/wait-for-block-after/{round}": {
+      "get": {
+        "description": "Waits for a block to appear after round {round} and returns the node's status at the time. There is a 1 minute timeout, when reached the current status is returned regardless of whether or not it is the round after the given round.",
+        "operationId": "WaitForBlock",
+        "parameters": [
+          {
+            "description": "A round number.",
+            "in": "path",
+            "name": "round",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "x-go-type": "basics.Round"
+            },
+            "x-go-type": "basics.Round"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "NodeStatus contains the information about a node status",
+                  "properties": {
+                    "catchpoint": {
+                      "description": "The current catchpoint that is being caught up to",
+                      "type": "string"
+                    },
+                    "catchpoint-acquired-blocks": {
+                      "description": "The number of blocks that have already been obtained by the node as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-processed-accounts": {
+                      "description": "The number of accounts from the current catchpoint that have been processed so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-processed-kvs": {
+                      "description": "The number of key-values (KVs) from the current catchpoint that have been processed so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-accounts": {
+                      "description": "The total number of accounts included in the current catchpoint",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-blocks": {
+                      "description": "The total number of blocks that are required to complete the current catchpoint catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-total-kvs": {
+                      "description": "The total number of key-values (KVs) included in the current catchpoint",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-verified-accounts": {
+                      "description": "The number of accounts from the current catchpoint that have been verified so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchpoint-verified-kvs": {
+                      "description": "The number of key-values (KVs) from the current catchpoint that have been verified so far as part of the catchup",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "catchup-time": {
+                      "description": "CatchupTime in nanoseconds",
+                      "type": "integer",
+                      "x-go-type": "int64"
+                    },
+                    "last-catchpoint": {
+                      "description": "The last catchpoint seen by the node",
+                      "type": "string"
+                    },
+                    "last-round": {
+                      "description": "LastRound indicates the last round seen",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "last-version": {
+                      "description": "LastVersion indicates the last consensus version supported",
+                      "type": "string"
+                    },
+                    "next-version": {
+                      "description": "NextVersion of consensus protocol to use",
+                      "type": "string"
+                    },
+                    "next-version-round": {
+                      "description": "NextVersionRound is the round at which the next consensus version will apply",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "next-version-supported": {
+                      "description": "NextVersionSupported indicates whether the next consensus version is supported by this node",
+                      "type": "boolean"
+                    },
+                    "stopped-at-unsupported-round": {
+                      "description": "StoppedAtUnsupportedRound indicates that the node does not support the new rounds and has stopped making progress",
+                      "type": "boolean"
+                    },
+                    "time-since-last-round": {
+                      "description": "TimeSinceLastRound in nanoseconds",
+                      "type": "integer",
+                      "x-go-type": "int64"
+                    },
+                    "upgrade-delay": {
+                      "description": "Upgrade delay",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-next-protocol-vote-before": {
+                      "description": "Next protocol round",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-no-votes": {
+                      "description": "No votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-node-vote": {
+                      "description": "This node's upgrade vote",
+                      "type": "boolean"
+                    },
+                    "upgrade-vote-rounds": {
+                      "description": "Total voting rounds for current upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-votes": {
+                      "description": "Total votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-votes-required": {
+                      "description": "Yes votes required for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "upgrade-yes-votes": {
+                      "description": "Yes votes cast for consensus upgrade",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    }
+                  },
+                  "required": [
+                    "catchup-time",
+                    "last-round",
+                    "last-version",
+                    "next-version",
+                    "next-version-round",
+                    "next-version-supported",
+                    "stopped-at-unsupported-round",
+                    "time-since-last-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request -- number must be non-negative integer"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Gets the node status after waiting for a round after the given round.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/teal/compile": {
+      "post": {
+        "description": "Given TEAL source code in plain text, return base64 encoded program bytes and base32 SHA512_256 hash of program bytes (Address style). This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
+        "operationId": "TealCompile",
+        "parameters": [
+          {
+            "description": "When set to `true`, returns the source map of the program as a JSON. Defaults to `false`.",
+            "in": "query",
+            "name": "sourcemap",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "TEAL source code to be compiled",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "hash": {
+                      "description": "base32 SHA512_256 of program bytes (Address style)",
+                      "type": "string"
+                    },
+                    "result": {
+                      "description": "base64 encoded program bytes",
+                      "type": "string"
+                    },
+                    "sourcemap": {
+                      "description": "JSON of the source map",
+                      "properties": {},
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "hash",
+                    "result"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Teal compile Result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Teal Compile Error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {},
+            "description": "Developer API not enabled"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Compile TEAL source code to binary, produce its hash",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ],
+        "x-codegen-request-body-name": "source"
+      }
+    },
+    "/v2/teal/disassemble": {
+      "post": {
+        "description": "Given the program bytes, return the TEAL source code in plain text. This endpoint is only enabled when a node's configuration file sets EnableDeveloperAPI to true.",
+        "operationId": "TealDisassemble",
+        "requestBody": {
+          "content": {
+            "application/x-binary": {
+              "schema": {
+                "format": "byte",
+                "type": "string"
+              }
+            }
+          },
+          "description": "TEAL program binary to be disassembled",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "result": {
+                      "description": "disassembled Teal code",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Teal disassembly Result"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Teal Compile Error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {},
+            "description": "Developer API not enabled"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Disassemble program bytes into the TEAL source code.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ],
+        "x-codegen-request-body-name": "source"
+      }
+    },
+    "/v2/transactions": {
+      "post": {
+        "operationId": "RawTransaction",
+        "parameters": [
+          {
+            "description": "Skip post-quantum address checks, including the check that rejects PQ authorizer and LogicSig escrow (TEAL v13 or later) whose address is an Edwards25519 curve point. This should only be used if you understand the risks and know what you are doing.",
+            "in": "query",
+            "name": "skip-pq-address-check",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-binary": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "The byte encoded signed transaction to broadcast to network",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "txId": {
+                      "description": "encoding of the transaction hash.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "txId"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transaction ID of the submission."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Malformed Algorand transaction "
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Broadcasts a raw transaction or transaction group to the network.",
+        "tags": [
+          "public",
+          "participating"
+        ],
+        "x-codegen-request-body-name": "rawtxn"
+      }
+    },
+    "/v2/transactions/async": {
+      "post": {
+        "operationId": "RawTransactionAsync",
+        "parameters": [
+          {
+            "description": "Skip post-quantum address checks, including the check that rejects PQ authorizer and LogicSig escrow (TEAL v13 or later) whose address is an Edwards25519 curve point. This should only be used if you understand the risks and know what you are doing.",
+            "in": "query",
+            "name": "skip-pq-address-check",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-binary": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
+            }
+          },
+          "description": "The byte encoded signed transaction to broadcast to network",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {}
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request - Malformed Algorand transaction "
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {},
+            "description": "Developer or Experimental API not enabled"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Fast track for broadcasting a raw transaction or transaction group to the network through the tx handler without performing most of the checks and reporting detailed errors. Should be only used for development and performance testing.",
+        "tags": [
+          "public",
+          "experimental"
+        ],
+        "x-codegen-request-body-name": "rawtxn"
+      }
+    },
+    "/v2/transactions/params": {
+      "get": {
+        "operationId": "TransactionParams",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "TransactionParams contains the parameters that help a client construct\na new transaction.",
+                  "properties": {
+                    "consensus-version": {
+                      "description": "ConsensusVersion indicates the consensus protocol version\nas of LastRound.",
+                      "type": "string"
+                    },
+                    "fee": {
+                      "description": "Fee is the suggested transaction fee\nFee is in units of micro-Algos per byte.\nFee may fall to zero but transactions must still have a fee of\nat least MinTxnFee for the current network protocol.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    },
+                    "genesis-hash": {
+                      "description": "GenesisHash is the hash of the genesis block.",
+                      "format": "byte",
+                      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+                      "type": "string"
+                    },
+                    "genesis-id": {
+                      "description": "GenesisID is an ID listed in the genesis block.",
+                      "type": "string"
+                    },
+                    "last-round": {
+                      "description": "LastRound indicates the last round seen",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "min-fee": {
+                      "description": "The minimum transaction fee (not per byte) required for the txn to validate for the current network protocol.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    }
+                  },
+                  "required": [
+                    "consensus-version",
+                    "fee",
+                    "genesis-hash",
+                    "genesis-id",
+                    "last-round",
+                    "min-fee"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "TransactionParams contains the parameters that help a client construct a new transaction."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get parameters for constructing a new transaction",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ]
+      }
+    },
+    "/v2/transactions/pending": {
+      "get": {
+        "description": "Get the list of pending transactions, sorted by priority, in decreasing order, truncated at the end at MAX. If MAX = 0, returns all pending transactions.",
+        "operationId": "GetPendingTransactions",
+        "parameters": [
+          {
+            "description": "Truncated number of transactions to display. If max=0, returns all pending txns.",
+            "in": "query",
+            "name": "max",
+            "schema": {
+              "type": "integer",
+              "x-go-type": "uint64"
+            },
+            "x-go-type": "uint64"
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "PendingTransactions is an array of signed transactions exactly as they were submitted.",
+                  "properties": {
+                    "top-transactions": {
+                      "description": "An array of signed transaction objects.",
+                      "items": {
+                        "properties": {},
+                        "type": "object",
+                        "x-algorand-format": "SignedTransaction"
+                      },
+                      "type": "array"
+                    },
+                    "total-transactions": {
+                      "description": "Total number of transactions in the pool.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "top-transactions",
+                    "total-transactions"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "description": "PendingTransactions is an array of signed transactions exactly as they were submitted.",
+                  "properties": {
+                    "top-transactions": {
+                      "description": "An array of signed transaction objects.",
+                      "items": {
+                        "properties": {},
+                        "type": "object",
+                        "x-algorand-format": "SignedTransaction"
+                      },
+                      "type": "array"
+                    },
+                    "total-transactions": {
+                      "description": "Total number of transactions in the pool.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "top-transactions",
+                    "total-transactions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "A potentially truncated list of transactions currently in the node's transaction pool. You can compute whether or not the list is truncated if the number of elements in the **top-transactions** array is fewer than **total-transactions**."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a list of unconfirmed transactions currently in the transaction pool.",
+        "tags": [
+          "public",
+          "participating"
+        ]
+      }
+    },
+    "/v2/transactions/pending/{txid}": {
+      "get": {
+        "description": "Given a transaction ID of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed:\n- transaction committed (committed round > 0)\n- transaction still in the pool (committed round = 0, pool error = \"\")\n- transaction removed from pool due to error (committed round = 0, pool error != \"\")\nOr the transaction may have happened sufficiently long ago that the node no longer remembers it, and this will return an error.",
+        "operationId": "PendingTransactionInformation",
+        "parameters": [
+          {
+            "description": "A transaction ID",
+            "in": "path",
+            "name": "txid",
+            "required": true,
+            "schema": {
+              "pattern": "[A-Z0-9]+",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingTransactionResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/PendingTransactionResponse"
+                }
+              }
+            },
+            "description": "Given a transaction ID of a recently submitted transaction, it returns information about it.  There are several cases when this might succeed:\n- transaction committed (committed round > 0)\n- transaction still in the pool (committed round = 0, pool error = \"\")\n- transaction removed from pool due to error (committed round = 0, pool error != \"\")\n\nOr the transaction may have happened sufficiently long ago that the node no longer remembers it, and this will return an error."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Transaction Not Found"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Get a specific pending transaction.",
+        "tags": [
+          "public",
+          "participating"
+        ]
+      }
+    },
+    "/v2/transactions/simulate": {
+      "post": {
+        "operationId": "SimulateTransaction",
+        "parameters": [
+          {
+            "description": "Configures whether the response object is JSON or MessagePack encoded. If not provided, defaults to JSON.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "json",
+                "msgpack"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulateRequest"
+              }
+            },
+            "application/msgpack": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulateRequest"
+              }
+            }
+          },
+          "description": "The transactions to simulate, along with any other inputs.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "eval-overrides": {
+                      "$ref": "#/components/schemas/SimulationEvalOverrides"
+                    },
+                    "exec-trace-config": {
+                      "$ref": "#/components/schemas/SimulateTraceConfig"
+                    },
+                    "initial-states": {
+                      "$ref": "#/components/schemas/SimulateInitialStates"
+                    },
+                    "last-round": {
+                      "description": "The round immediately preceding this simulation. State changes through this round were used to run this simulation.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "txn-groups": {
+                      "description": "A result object for each transaction group that was simulated.",
+                      "items": {
+                        "$ref": "#/components/schemas/SimulateTransactionGroupResult"
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "description": "The version of this response object.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    }
+                  },
+                  "required": [
+                    "last-round",
+                    "txn-groups",
+                    "version"
+                  ],
+                  "type": "object"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "properties": {
+                    "eval-overrides": {
+                      "$ref": "#/components/schemas/SimulationEvalOverrides"
+                    },
+                    "exec-trace-config": {
+                      "$ref": "#/components/schemas/SimulateTraceConfig"
+                    },
+                    "initial-states": {
+                      "$ref": "#/components/schemas/SimulateInitialStates"
+                    },
+                    "last-round": {
+                      "description": "The round immediately preceding this simulation. State changes through this round were used to run this simulation.",
+                      "type": "integer",
+                      "x-go-type": "basics.Round"
+                    },
+                    "txn-groups": {
+                      "description": "A result object for each transaction group that was simulated.",
+                      "items": {
+                        "$ref": "#/components/schemas/SimulateTransactionGroupResult"
+                      },
+                      "type": "array"
+                    },
+                    "version": {
+                      "description": "The version of this response object.",
+                      "type": "integer",
+                      "x-go-type": "uint64"
+                    }
+                  },
+                  "required": [
+                    "last-round",
+                    "txn-groups",
+                    "version"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Result of a transaction group simulation."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid API Token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Internal Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              },
+              "application/msgpack": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Service Temporarily Unavailable"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Simulates a raw transaction or transaction group as it would be evaluated on the network. The simulation will use blockchain state from the latest committed round.",
+        "tags": [
+          "public",
+          "nonparticipating"
+        ],
+        "x-codegen-request-body-name": "request"
+      }
+    },
+    "/versions": {
+      "get": {
+        "description": "Retrieves the supported API versions, binary build versions, and genesis information.",
+        "operationId": "GetVersion",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Version"
+                }
+              }
+            },
+            "description": "VersionsResponse is the response to 'GET /versions'"
+          }
+        },
+        "tags": [
+          "public",
+          "common"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost/"
+    },
+    {
+      "url": "https://localhost/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "private"
+    }
+  ],
+  "x-original-swagger-version": "2.0"
+}

--- a/openapi/indexer.json
+++ b/openapi/indexer.json
@@ -1,0 +1,5824 @@
+{
+  "components": {
+    "parameters": {
+      "absent": {
+        "description": "Accounts marked as absent in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+        "explode": false,
+        "in": "query",
+        "name": "absent",
+        "schema": {
+          "items": {
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "type": "array"
+        },
+        "style": "form"
+      },
+      "account-id": {
+        "description": "account string",
+        "in": "path",
+        "name": "account-id",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "address": {
+        "description": "Only include transactions with this address in one of the transaction fields.",
+        "in": "query",
+        "name": "address",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "Address"
+        },
+        "x-algorand-format": "Address"
+      },
+      "address-role": {
+        "description": "Combine with the address parameter to define what type of address to search for.",
+        "in": "query",
+        "name": "address-role",
+        "schema": {
+          "enum": [
+            "sender",
+            "receiver",
+            "freeze-target"
+          ],
+          "type": "string"
+        }
+      },
+      "after-time": {
+        "description": "Include results after the given time. Must be an RFC 3339 formatted string.",
+        "in": "query",
+        "name": "after-time",
+        "schema": {
+          "format": "date-time",
+          "type": "string",
+          "x-algorand-format": "RFC3339 String"
+        },
+        "x-algorand-format": "RFC3339 String"
+      },
+      "application-id": {
+        "description": "Application ID",
+        "in": "query",
+        "name": "application-id",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "asset-id": {
+        "description": "Asset ID",
+        "in": "query",
+        "name": "asset-id",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "auth-addr": {
+        "description": "Include accounts configured to use this spending key.",
+        "in": "query",
+        "name": "auth-addr",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "Address"
+        },
+        "x-algorand-format": "Address"
+      },
+      "before-time": {
+        "description": "Include results before the given time. Must be an RFC 3339 formatted string.",
+        "in": "query",
+        "name": "before-time",
+        "schema": {
+          "format": "date-time",
+          "type": "string",
+          "x-algorand-format": "RFC3339 String"
+        },
+        "x-algorand-format": "RFC3339 String"
+      },
+      "box-name": {
+        "description": "A box name in goal-arg form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, use the form 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.",
+        "in": "query",
+        "name": "name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "currency-greater-than": {
+        "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+        "in": "query",
+        "name": "currency-greater-than",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "currency-less-than": {
+        "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+        "in": "query",
+        "name": "currency-less-than",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "exclude": {
+        "description": "Exclude additional items such as asset holdings, application local data stored for this account, asset parameters created by this account, and application parameters created by this account.",
+        "explode": false,
+        "in": "query",
+        "name": "exclude",
+        "schema": {
+          "items": {
+            "enum": [
+              "all",
+              "assets",
+              "created-assets",
+              "apps-local-state",
+              "created-apps",
+              "none"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "style": "form"
+      },
+      "exclude-close-to": {
+        "description": "Combine with address and address-role parameters to define what type of address to search for. The close to fields are normally treated as a receiver, if you would like to exclude them set this parameter to true.",
+        "in": "query",
+        "name": "exclude-close-to",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "expired": {
+        "description": "Accounts marked as expired in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+        "explode": false,
+        "in": "query",
+        "name": "expired",
+        "schema": {
+          "items": {
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "type": "array"
+        },
+        "style": "form"
+      },
+      "group-id": {
+        "description": "Lookup transactions by group ID. This field must be base64-encoded, and afterwards, base64 characters that are URL-unsafe (i.e. =, /, +) must be URL-encoded",
+        "in": "query",
+        "name": "group-id",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "base64"
+        },
+        "x-algorand-format": "base64"
+      },
+      "header-only": {
+        "description": "Header only flag. When this is set to true, returned block does not contain the transactions",
+        "in": "query",
+        "name": "header-only",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "include-all": {
+        "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+        "in": "query",
+        "name": "include-all",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "limit": {
+        "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+        "in": "query",
+        "name": "limit",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "max-round": {
+        "description": "Include results at or before the specified max-round.",
+        "in": "query",
+        "name": "max-round",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "min-round": {
+        "description": "Include results at or after the specified min-round.",
+        "in": "query",
+        "name": "min-round",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "next": {
+        "description": "The next page of results. Use the next token provided by the previous results.",
+        "in": "query",
+        "name": "next",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "note-prefix": {
+        "description": "Specifies a prefix which must be contained in the note field.",
+        "in": "query",
+        "name": "note-prefix",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "base64"
+        },
+        "x-algorand-format": "base64"
+      },
+      "online-only": {
+        "description": "When this is set to true, return only accounts whose participation status is currently online.",
+        "in": "query",
+        "name": "online-only",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "proposers": {
+        "description": "Accounts marked as proposer in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+        "explode": false,
+        "in": "query",
+        "name": "proposers",
+        "schema": {
+          "items": {
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "type": "array"
+        },
+        "style": "form"
+      },
+      "rekey-to": {
+        "description": "Include results which include the rekey-to field.",
+        "in": "query",
+        "name": "rekey-to",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "round": {
+        "description": "Include results for the specified round.",
+        "in": "query",
+        "name": "round",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "round-number": {
+        "description": "Round number",
+        "in": "path",
+        "name": "round-number",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "sender-address": {
+        "description": "Only include transactions with this sender address.",
+        "in": "query",
+        "name": "sender-address",
+        "schema": {
+          "type": "string",
+          "x-algorand-format": "Address"
+        },
+        "x-algorand-format": "Address"
+      },
+      "sig-type": {
+        "description": "SigType filters just results using the specified type of signature:\n* sig - Standard\n* msig - MultiSig\n* lsig - LogicSig\n* pqsig - Post-Quantum",
+        "in": "query",
+        "name": "sig-type",
+        "schema": {
+          "enum": [
+            "sig",
+            "msig",
+            "lsig",
+            "pqsig"
+          ],
+          "type": "string"
+        }
+      },
+      "tx-type": {
+        "in": "query",
+        "name": "tx-type",
+        "schema": {
+          "enum": [
+            "pay",
+            "keyreg",
+            "acfg",
+            "axfer",
+            "afrz",
+            "appl",
+            "stpf",
+            "hb"
+          ],
+          "type": "string"
+        }
+      },
+      "txid": {
+        "description": "Lookup the specific transaction by ID.",
+        "in": "query",
+        "name": "txid",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "AccountResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "account",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "AccountsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "accounts": {
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "accounts",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "ApplicationLocalStatesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "apps-local-states": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApplicationLocalState"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "apps-local-states",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "ApplicationLogsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "application-id": {
+                  "description": "\\[appidx\\] application index.",
+                  "type": "integer"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "log-data": {
+                  "items": {
+                    "$ref": "#/components/schemas/ApplicationLogData"
+                  },
+                  "type": "array"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "application-id",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "ApplicationResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "application": {
+                  "$ref": "#/components/schemas/Application"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "ApplicationsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "applications": {
+                  "items": {
+                    "$ref": "#/components/schemas/Application"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "applications",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "AssetBalancesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "balances": {
+                  "items": {
+                    "$ref": "#/components/schemas/MiniAssetHolding"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "balances",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "AssetHoldingsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "assets": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssetHolding"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "assets",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "AssetResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "asset": {
+                  "$ref": "#/components/schemas/Asset"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "asset",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "AssetsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "assets": {
+                  "items": {
+                    "$ref": "#/components/schemas/Asset"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "assets",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "BlockHeadersResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "blocks": {
+                  "items": {
+                    "$ref": "#/components/schemas/Block"
+                  },
+                  "type": "array"
+                },
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "blocks",
+                "current-round"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "BlockResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Block"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "BoxResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Box"
+            }
+          }
+        },
+        "description": "Box information"
+      },
+      "BoxesResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "application-id": {
+                  "description": "\\[appidx\\] application index.",
+                  "type": "integer"
+                },
+                "boxes": {
+                  "items": {
+                    "$ref": "#/components/schemas/BoxDescriptor"
+                  },
+                  "type": "array"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                },
+                "round": {
+                  "description": "The round for which this information is relevant.",
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "application-id",
+                "boxes"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Box names of an application"
+      },
+      "ErrorResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "data": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "message"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "Response for errors"
+      },
+      "HealthCheckResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/HealthCheck"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "TransactionResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "transaction": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              },
+              "required": [
+                "current-round",
+                "transaction"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      },
+      "TransactionsResponse": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "current-round": {
+                  "description": "Round at which the results were computed.",
+                  "type": "integer"
+                },
+                "next-token": {
+                  "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                  "type": "string"
+                },
+                "transactions": {
+                  "items": {
+                    "$ref": "#/components/schemas/Transaction"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "current-round",
+                "transactions"
+              ],
+              "type": "object"
+            }
+          }
+        },
+        "description": "(empty)"
+      }
+    },
+    "schemas": {
+      "Account": {
+        "description": "Account information at a given round.\n\nDefinition:\ndata/basics/userBalance.go : AccountData\n",
+        "properties": {
+          "address": {
+            "description": "the account public key",
+            "type": "string"
+          },
+          "amount": {
+            "description": "total number of MicroAlgos in the account",
+            "type": "integer"
+          },
+          "amount-without-pending-rewards": {
+            "description": "specifies the amount of MicroAlgos in the account, without the pending rewards.",
+            "type": "integer"
+          },
+          "apps-local-state": {
+            "description": "application local data stored in this account.\n\nNote the raw object uses `map[int] -> AppLocalState` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationLocalState"
+            },
+            "type": "array"
+          },
+          "apps-total-extra-pages": {
+            "description": "the sum of all extra application program pages for this account.",
+            "type": "integer"
+          },
+          "apps-total-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "assets": {
+            "description": "assets held by this account.\n\nNote the raw object uses `map[int] -> AssetHolding` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/AssetHolding"
+            },
+            "type": "array"
+          },
+          "auth-addr": {
+            "description": "The address against which signing should be checked. If empty, the address of the current account is used. This field can be updated in any transaction by setting the RekeyTo field.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "closed-at-round": {
+            "description": "Round during which this account was most recently closed.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "created-apps": {
+            "description": "parameters of applications created by this account including app global data.\n\nNote: the raw account uses `map[int] -> AppParams` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            },
+            "type": "array"
+          },
+          "created-assets": {
+            "description": "parameters of assets created by this account.\n\nNote: the raw account uses `map[int] -> Asset` for this type.",
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            },
+            "type": "array"
+          },
+          "created-at-round": {
+            "description": "Round during which this account first appeared in a transaction.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "deleted": {
+            "description": "Whether or not this account is currently closed.",
+            "type": "boolean"
+          },
+          "incentive-eligible": {
+            "description": "can the account receive block incentives if its balance is in range at proposal time.",
+            "type": "boolean"
+          },
+          "last-heartbeat": {
+            "description": "The round in which this account last went online, or explicitly renewed their online status.",
+            "type": "integer"
+          },
+          "last-proposed": {
+            "description": "The round in which this account last proposed the block.",
+            "type": "integer"
+          },
+          "min-balance": {
+            "description": "MicroAlgo balance required by the account.\n\nThe requirement grows based on asset and application usage.",
+            "type": "integer"
+          },
+          "participation": {
+            "$ref": "#/components/schemas/AccountParticipation"
+          },
+          "pending-rewards": {
+            "description": "amount of MicroAlgos of pending rewards in this account.",
+            "type": "integer"
+          },
+          "reward-base": {
+            "description": "used as part of the rewards computation. Only applicable to accounts which are participating.",
+            "type": "integer"
+          },
+          "rewards": {
+            "description": "total rewards of MicroAlgos the account has received, including pending rewards.",
+            "type": "integer"
+          },
+          "round": {
+            "description": "The round for which this information is relevant.",
+            "type": "integer"
+          },
+          "sig-type": {
+            "description": "the type of signature used by this account, must be one of:\n* sig\n* msig\n* lsig\n* pqsig\n* or null if unknown",
+            "enum": [
+              "sig",
+              "msig",
+              "lsig",
+              "pqsig"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "description": "voting status of the account's MicroAlgos\n* Offline - indicates that the associated account is delegated.\n*  Online  - indicates that the associated account used as part of the delegation pool.\n*   NotParticipating - indicates that the associated account is neither a delegator nor a delegate.",
+            "type": "string"
+          },
+          "total-apps-opted-in": {
+            "description": "The count of all applications that have been opted in, equivalent to the count of application local data (AppLocalState objects) stored in this account.",
+            "type": "integer"
+          },
+          "total-assets-opted-in": {
+            "description": "The count of all assets that have been opted in, equivalent to the count of AssetHolding objects held by this account.",
+            "type": "integer"
+          },
+          "total-box-bytes": {
+            "description": "For app-accounts only. The total number of bytes allocated for the keys and values of boxes which belong to the associated application.",
+            "type": "integer"
+          },
+          "total-boxes": {
+            "description": "For app-accounts only. The total number of boxes which belong to the associated application.",
+            "type": "integer"
+          },
+          "total-created-apps": {
+            "description": "The count of all apps (AppParams objects) created by this account.",
+            "type": "integer"
+          },
+          "total-created-assets": {
+            "description": "The count of all assets (AssetParams objects) created by this account.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "address",
+          "amount",
+          "amount-without-pending-rewards",
+          "min-balance",
+          "pending-rewards",
+          "rewards",
+          "round",
+          "status",
+          "total-apps-opted-in",
+          "total-assets-opted-in",
+          "total-box-bytes",
+          "total-boxes",
+          "total-created-apps",
+          "total-created-assets"
+        ],
+        "type": "object"
+      },
+      "AccountParticipation": {
+        "description": "AccountParticipation describes the parameters used by this account in consensus protocol.",
+        "properties": {
+          "selection-participation-key": {
+            "description": "Selection public key (if any) currently registered for this round.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "state-proof-key": {
+            "description": "Root of the state proof key (if any)",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "vote-first-valid": {
+            "description": "First round for which this participation is valid.",
+            "type": "integer"
+          },
+          "vote-key-dilution": {
+            "description": "Number of subkeys in each batch of participation keys.",
+            "type": "integer"
+          },
+          "vote-last-valid": {
+            "description": "Last round for which this participation is valid.",
+            "type": "integer"
+          },
+          "vote-participation-key": {
+            "description": "root participation public key (if any) currently registered for this round.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "selection-participation-key",
+          "vote-first-valid",
+          "vote-key-dilution",
+          "vote-last-valid",
+          "vote-participation-key"
+        ],
+        "type": "object"
+      },
+      "AccountStateDelta": {
+        "description": "Application state delta.",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "delta": {
+            "$ref": "#/components/schemas/StateDelta"
+          }
+        },
+        "required": [
+          "address",
+          "delta"
+        ],
+        "type": "object"
+      },
+      "Application": {
+        "description": "Application index and its parameters",
+        "properties": {
+          "created-at-round": {
+            "description": "Round when this application was created.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "deleted": {
+            "description": "Whether or not this application is currently deleted.",
+            "type": "boolean"
+          },
+          "deleted-at-round": {
+            "description": "Round when this application was deleted.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "id": {
+            "description": "application index.",
+            "type": "integer"
+          },
+          "params": {
+            "$ref": "#/components/schemas/ApplicationParams"
+          }
+        },
+        "required": [
+          "id",
+          "params"
+        ],
+        "type": "object"
+      },
+      "ApplicationLocalState": {
+        "description": "Stores local state associated with an application.",
+        "properties": {
+          "closed-out-at-round": {
+            "description": "Round when account closed out of the application.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "deleted": {
+            "description": "Whether or not the application local state is currently deleted from its account.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The application which this local state is for.",
+            "type": "integer"
+          },
+          "key-value": {
+            "$ref": "#/components/schemas/TealKeyValueStore"
+          },
+          "opted-in-at-round": {
+            "description": "Round when the account opted into the application.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          }
+        },
+        "required": [
+          "id",
+          "schema"
+        ],
+        "type": "object"
+      },
+      "ApplicationLogData": {
+        "description": "Stores the global information associated with an application.",
+        "properties": {
+          "logs": {
+            "description": "Logs for the application being executed by the transaction.",
+            "items": {
+              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "txid": {
+            "description": "Transaction ID",
+            "type": "string"
+          }
+        },
+        "required": [
+          "logs",
+          "txid"
+        ],
+        "type": "object"
+      },
+      "ApplicationParams": {
+        "description": "Stores the global information associated with an application.",
+        "properties": {
+          "approval-program": {
+            "description": "approval program.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "clear-state-program": {
+            "description": "clear state program.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "creator": {
+            "description": "The address that created this application. This is the address where the parameters and global state for this application can be found.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "extra-program-pages": {
+            "description": "the number of extra program pages available to this app.",
+            "type": "integer"
+          },
+          "global-state": {
+            "$ref": "#/components/schemas/TealKeyValueStore"
+          },
+          "global-state-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "local-state-schema": {
+            "$ref": "#/components/schemas/ApplicationStateSchema"
+          },
+          "version": {
+            "description": "the number of updates to the application programs",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "approval-program",
+          "clear-state-program"
+        ],
+        "type": "object"
+      },
+      "ApplicationStateSchema": {
+        "description": "Specifies maximums on the number of each type that may be stored.",
+        "properties": {
+          "num-byte-slice": {
+            "description": "number of byte slices.",
+            "type": "integer"
+          },
+          "num-uint": {
+            "description": "number of uints.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "num-byte-slice",
+          "num-uint"
+        ],
+        "type": "object"
+      },
+      "Asset": {
+        "description": "Specifies both the unique identifier and the parameters for an asset",
+        "properties": {
+          "created-at-round": {
+            "description": "Round during which this asset was created.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "deleted": {
+            "description": "Whether or not this asset is currently deleted.",
+            "type": "boolean"
+          },
+          "destroyed-at-round": {
+            "description": "Round during which this asset was destroyed.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "index": {
+            "description": "unique asset identifier",
+            "type": "integer"
+          },
+          "params": {
+            "$ref": "#/components/schemas/AssetParams"
+          }
+        },
+        "required": [
+          "index",
+          "params"
+        ],
+        "type": "object"
+      },
+      "AssetHolding": {
+        "description": "Describes an asset held by an account.\n\nDefinition:\ndata/basics/userBalance.go : AssetHolding",
+        "properties": {
+          "amount": {
+            "description": "number of units held.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "asset-id": {
+            "description": "Asset ID of the holding.",
+            "type": "integer"
+          },
+          "deleted": {
+            "description": "Whether or not the asset holding is currently deleted from its account.",
+            "type": "boolean"
+          },
+          "is-frozen": {
+            "description": "whether or not the holding is frozen.",
+            "type": "boolean"
+          },
+          "opted-in-at-round": {
+            "description": "Round during which the account opted into this asset holding.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "opted-out-at-round": {
+            "description": "Round during which the account opted out of this asset holding.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "amount",
+          "asset-id",
+          "is-frozen"
+        ],
+        "type": "object"
+      },
+      "AssetParams": {
+        "description": "AssetParams specifies the parameters for an asset.\n\n\\[apar\\] when part of an AssetConfig transaction.\n\nDefinition:\ndata/transactions/asset.go : AssetParams",
+        "properties": {
+          "clawback": {
+            "description": "Address of account used to clawback holdings of this asset.  If empty, clawback is not permitted.",
+            "type": "string"
+          },
+          "creator": {
+            "description": "The address that created this asset. This is the address where the parameters for this asset can be found, and also the address where unwanted asset units can be sent in the worst case.",
+            "type": "string"
+          },
+          "decimals": {
+            "description": "The number of digits to use after the decimal point when displaying this asset. If 0, the asset is not divisible. If 1, the base unit of the asset is in tenths. If 2, the base unit of the asset is in hundredths, and so on. This value must be between 0 and 19 (inclusive).",
+            "maximum": 19,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "default-frozen": {
+            "description": "Whether holdings of this asset are frozen by default.",
+            "type": "boolean"
+          },
+          "freeze": {
+            "description": "Address of account used to freeze holdings of this asset.  If empty, freezing is not permitted.",
+            "type": "string"
+          },
+          "manager": {
+            "description": "Address of account used to manage the keys of this asset and to destroy it.",
+            "type": "string"
+          },
+          "metadata-hash": {
+            "description": "A commitment to some unspecified asset metadata. The format of this metadata is up to the application.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of this asset, as supplied by the creator. Included only when the asset name is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "name-b64": {
+            "description": "Base64 encoded name of this asset, as supplied by the creator.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "reserve": {
+            "description": "Address of account holding reserve (non-minted) units of this asset.",
+            "type": "string"
+          },
+          "total": {
+            "description": "The total number of units of this asset.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "unit-name": {
+            "description": "Name of a unit of this asset, as supplied by the creator. Included only when the name of a unit of this asset is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "unit-name-b64": {
+            "description": "Base64 encoded name of a unit of this asset, as supplied by the creator.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL where more information about the asset can be retrieved. Included only when the URL is composed of printable utf-8 characters.",
+            "type": "string"
+          },
+          "url-b64": {
+            "description": "Base64 encoded URL where more information about the asset can be retrieved.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "creator",
+          "decimals",
+          "total"
+        ],
+        "type": "object"
+      },
+      "Block": {
+        "description": "Block information.\n\nDefinition:\ndata/bookkeeping/block.go : Block",
+        "properties": {
+          "bonus": {
+            "description": "the potential bonus payout for this block.",
+            "type": "integer"
+          },
+          "congestion-tax": {
+            "description": "the fee required, beyond the minimum fee, for \"normal\" transactions in this block.",
+            "type": "integer"
+          },
+          "fees-collected": {
+            "description": "the sum of all fees paid by transactions in this block.",
+            "type": "integer"
+          },
+          "genesis-hash": {
+            "description": "\\[gh\\] hash to which this block belongs.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "genesis-id": {
+            "description": "\\[gen\\] ID to which this block belongs.",
+            "type": "string"
+          },
+          "load": {
+            "description": "the degree to which this block is full, based on the number of bytes in the final block compared to the maximum allowed. Expressed as a fixed-point integer with 6 digits of precision, so 1,000,000 is a completely full block.",
+            "type": "integer"
+          },
+          "participation-updates": {
+            "$ref": "#/components/schemas/ParticipationUpdates"
+          },
+          "previous-block-hash": {
+            "description": "\\[prev\\] Previous block hash.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "previous-block-hash-512": {
+            "description": "\\[prev512\\] Previous block hash, using SHA-512.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "proposer": {
+            "description": "the proposer of this block.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "proposer-payout": {
+            "description": "the actual amount transferred to the proposer from the fee sink.",
+            "type": "integer"
+          },
+          "rewards": {
+            "$ref": "#/components/schemas/BlockRewards"
+          },
+          "round": {
+            "description": "\\[rnd\\] Current round on which this block was appended to the chain.",
+            "type": "integer"
+          },
+          "seed": {
+            "description": "\\[seed\\] Sortition seed.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "state-proof-tracking": {
+            "description": "Tracks the status of state proofs.",
+            "items": {
+              "$ref": "#/components/schemas/StateProofTracking"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "description": "\\[ts\\] Block creation timestamp in seconds since eposh",
+            "type": "integer"
+          },
+          "transactions": {
+            "description": "\\[txns\\] list of transactions corresponding to a given round.",
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            },
+            "type": "array"
+          },
+          "transactions-root": {
+            "description": "\\[txn\\] TransactionsRoot authenticates the set of transactions appearing in the block. More specifically, it's the root of a merkle tree whose leaves are the block's Txids, in lexicographic order. For the empty block, it's 0. Note that the TxnRoot does not authenticate the signatures on the transactions, only the transactions themselves. Two blocks with the same transactions but in a different order and with different signatures will have the same TxnRoot.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "transactions-root-sha256": {
+            "description": "\\[txn256\\] TransactionsRootSHA256 is an auxiliary TransactionRoot, built using a vector commitment instead of a merkle tree, and SHA256 hash function instead of the default SHA512_256. This commitment can be used on environments where only the SHA256 function exists.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "transactions-root-sha512": {
+            "description": "\\[txn512\\] TransactionsRootSHA512 is an auxiliary TransactionRoot, built using a vector commitment instead of a merkle tree, and SHA512 hash function instead of the default SHA512_256.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "txn-counter": {
+            "description": "\\[tc\\] TxnCounter counts the number of transactions committed in the ledger, from the time at which support for this feature was introduced.\n\nSpecifically, TxnCounter is the number of the next transaction that will be committed after this block.  It is 0 when no transactions have ever been committed (since TxnCounter started being supported).",
+            "type": "integer"
+          },
+          "upgrade-state": {
+            "$ref": "#/components/schemas/BlockUpgradeState"
+          },
+          "upgrade-vote": {
+            "$ref": "#/components/schemas/BlockUpgradeVote"
+          }
+        },
+        "required": [
+          "genesis-hash",
+          "genesis-id",
+          "previous-block-hash",
+          "round",
+          "seed",
+          "timestamp",
+          "transactions-root",
+          "transactions-root-sha256"
+        ],
+        "type": "object"
+      },
+      "BlockRewards": {
+        "description": "Fields relating to rewards,",
+        "properties": {
+          "fee-sink": {
+            "description": "\\[fees\\] accepts transaction fees, it can only spend to the incentive pool.",
+            "type": "string"
+          },
+          "rewards-calculation-round": {
+            "description": "\\[rwcalr\\] number of leftover MicroAlgos after the distribution of rewards-rate MicroAlgos for every reward unit in the next round.",
+            "type": "integer"
+          },
+          "rewards-level": {
+            "description": "\\[earn\\] How many rewards, in MicroAlgos, have been distributed to each RewardUnit of MicroAlgos since genesis.",
+            "type": "integer"
+          },
+          "rewards-pool": {
+            "description": "\\[rwd\\] accepts periodic injections from the fee-sink and continually redistributes them as rewards.",
+            "type": "string"
+          },
+          "rewards-rate": {
+            "description": "\\[rate\\] Number of new MicroAlgos added to the participation stake from rewards at the next round.",
+            "type": "integer"
+          },
+          "rewards-residue": {
+            "description": "\\[frac\\] Number of leftover MicroAlgos after the distribution of RewardsRate/rewardUnits MicroAlgos for every reward unit in the next round.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fee-sink",
+          "rewards-calculation-round",
+          "rewards-level",
+          "rewards-pool",
+          "rewards-rate",
+          "rewards-residue"
+        ],
+        "type": "object"
+      },
+      "BlockUpgradeState": {
+        "description": "Fields relating to a protocol upgrade.",
+        "properties": {
+          "current-protocol": {
+            "description": "\\[proto\\] The current protocol version.",
+            "type": "string"
+          },
+          "next-protocol": {
+            "description": "\\[nextproto\\] The next proposed protocol version.",
+            "type": "string"
+          },
+          "next-protocol-approvals": {
+            "description": "\\[nextyes\\] Number of blocks which approved the protocol upgrade.",
+            "type": "integer"
+          },
+          "next-protocol-switch-on": {
+            "description": "\\[nextswitch\\] Round on which the protocol upgrade will take effect.",
+            "type": "integer"
+          },
+          "next-protocol-vote-before": {
+            "description": "\\[nextbefore\\] Deadline round for this protocol upgrade (No votes will be consider after this round).",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "current-protocol"
+        ],
+        "type": "object"
+      },
+      "BlockUpgradeVote": {
+        "description": "Fields relating to voting for a protocol upgrade.",
+        "properties": {
+          "upgrade-approve": {
+            "description": "\\[upgradeyes\\] Indicates a yes vote for the current proposal.",
+            "type": "boolean"
+          },
+          "upgrade-delay": {
+            "description": "\\[upgradedelay\\] Indicates the time between acceptance and execution.",
+            "type": "integer"
+          },
+          "upgrade-propose": {
+            "description": "\\[upgradeprop\\] Indicates a proposed upgrade.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Box": {
+        "description": "Box name and its content.",
+        "properties": {
+          "name": {
+            "description": "\\[name\\] box name, base64 encoded",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "round": {
+            "description": "The round for which this information is relevant",
+            "type": "integer"
+          },
+          "value": {
+            "description": "\\[value\\] box value, base64 encoded.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "round",
+          "value"
+        ],
+        "type": "object"
+      },
+      "BoxDescriptor": {
+        "description": "Box descriptor describes an app box.",
+        "properties": {
+          "name": {
+            "description": "Base64 encoded box name",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "value": {
+            "description": "Base64 encoded box value. Present only when the `values` query parameter is set to true.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "BoxReference": {
+        "description": "BoxReference names a box by its name and the application ID it belongs to.",
+        "properties": {
+          "app": {
+            "description": "Application ID to which the box belongs, or zero if referring to the called application.",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Base64 encoded box name",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "app",
+          "name"
+        ],
+        "type": "object"
+      },
+      "EvalDelta": {
+        "description": "Represents a TEAL value delta.",
+        "properties": {
+          "action": {
+            "description": "\\[at\\] delta action.",
+            "type": "integer"
+          },
+          "bytes": {
+            "description": "\\[bs\\] bytes value.",
+            "type": "string"
+          },
+          "uint": {
+            "description": "\\[ui\\] uint value.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "type": "object"
+      },
+      "EvalDeltaKeyValue": {
+        "description": "Key-value pairs for StateDelta.",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/EvalDelta"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "HashFactory": {
+        "properties": {
+          "hash-type": {
+            "description": "\\[t\\]",
+            "type": "integer",
+            "x-algorand-format": "uint16"
+          }
+        },
+        "type": "object"
+      },
+      "Hashtype": {
+        "description": "The type of hash function used to create the proof, must be one of: \n* sha512_256 \n* sha256",
+        "enum": [
+          "sha512_256",
+          "sha256"
+        ],
+        "type": "string"
+      },
+      "HbProofFields": {
+        "description": "\\[hbprf\\] HbProof is a signature using HeartbeatAddress's partkey, thereby showing it is online.",
+        "properties": {
+          "hb-pk": {
+            "description": "\\[p\\] Public key of the heartbeat message.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "hb-pk1sig": {
+            "description": "\\[p1s\\] Signature of OneTimeSignatureSubkeyOffsetID(PK, Batch, Offset) under the key PK2.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "hb-pk2": {
+            "description": "\\[p2\\] Key for new-style two-level ephemeral signature.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "hb-pk2sig": {
+            "description": "\\[p2s\\] Signature of OneTimeSignatureSubkeyBatchID(PK2, Batch) under the master key (OneTimeSignatureVerifier).",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "hb-sig": {
+            "description": "\\[s\\] Signature of the heartbeat message.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "HealthCheck": {
+        "description": "A health check response.",
+        "properties": {
+          "data": {
+            "properties": {},
+            "type": "object"
+          },
+          "db-available": {
+            "type": "boolean"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "is-migrating": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "round": {
+            "type": "integer"
+          },
+          "version": {
+            "description": "Current version.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "db-available",
+          "is-migrating",
+          "message",
+          "round",
+          "version"
+        ],
+        "type": "object"
+      },
+      "HoldingRef": {
+        "description": "HoldingRef names a holding by referring to an Address and Asset it belongs to.",
+        "properties": {
+          "address": {
+            "description": "\\[d\\] Address in access list, or the sender of the transaction.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "asset": {
+            "description": "\\[s\\] Asset ID for asset in access list.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "address",
+          "asset"
+        ],
+        "type": "object"
+      },
+      "IndexerStateProofMessage": {
+        "properties": {
+          "block-headers-commitment": {
+            "description": "\\[b\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "first-attested-round": {
+            "description": "\\[f\\]",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "latest-attested-round": {
+            "description": "\\[l\\]",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "ln-proven-weight": {
+            "description": "\\[P\\]",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "voters-commitment": {
+            "description": "\\[v\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "LocalsRef": {
+        "description": "LocalsRef names a local state by referring to an Address and App it belongs to.",
+        "properties": {
+          "address": {
+            "description": "\\[d\\] Address in access list, or the sender of the transaction.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "app": {
+            "description": "\\[p\\] Application ID for app in access list, or zero if referring to the called application.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "address",
+          "app"
+        ],
+        "type": "object"
+      },
+      "MerkleArrayProof": {
+        "properties": {
+          "hash-factory": {
+            "$ref": "#/components/schemas/HashFactory"
+          },
+          "path": {
+            "description": "\\[pth\\]",
+            "items": {
+              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tree-depth": {
+            "description": "\\[td\\]",
+            "type": "integer",
+            "x-algorand-format": "uint8"
+          }
+        },
+        "type": "object"
+      },
+      "MiniAssetHolding": {
+        "description": "A simplified version of AssetHolding ",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "deleted": {
+            "description": "Whether or not this asset holding is currently deleted from its account.",
+            "type": "boolean"
+          },
+          "is-frozen": {
+            "type": "boolean"
+          },
+          "opted-in-at-round": {
+            "description": "Round during which the account opted into the asset.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "opted-out-at-round": {
+            "description": "Round during which the account opted out of the asset.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "address",
+          "amount",
+          "is-frozen"
+        ],
+        "type": "object"
+      },
+      "OnCompletion": {
+        "description": "\\[apan\\] defines the what additional actions occur with the transaction.\n\nValid types:\n* noop\n* optin\n* closeout\n* clear\n* update\n* update\n* delete",
+        "enum": [
+          "noop",
+          "optin",
+          "closeout",
+          "clear",
+          "update",
+          "delete"
+        ],
+        "type": "string"
+      },
+      "ParticipationUpdates": {
+        "description": "Participation account data that needs to be checked/acted on by the network.",
+        "properties": {
+          "absent-participation-accounts": {
+            "description": "\\[partupabs\\] a list of online accounts that need to be suspended.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "expired-participation-accounts": {
+            "description": "\\[partupdrmv\\] a list of online accounts that needs to be converted to offline since their participation key expired.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ResourceRef": {
+        "description": "ResourceRef names a single resource. Only one of the fields should be set.",
+        "properties": {
+          "address": {
+            "description": "\\[d\\] Account whose balance record is accessible by the executing ApprovalProgram or ClearStateProgram.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "application-id": {
+            "description": "\\[p\\] Application id whose GlobalState may be read by the executing\n ApprovalProgram or ClearStateProgram.",
+            "type": "integer"
+          },
+          "asset-id": {
+            "description": "\\[s\\] Asset whose AssetParams may be read by the executing\n ApprovalProgram or ClearStateProgram.",
+            "type": "integer"
+          },
+          "box": {
+            "$ref": "#/components/schemas/BoxReference"
+          },
+          "holding": {
+            "$ref": "#/components/schemas/HoldingRef"
+          },
+          "local": {
+            "$ref": "#/components/schemas/LocalsRef"
+          }
+        },
+        "type": "object"
+      },
+      "StateDelta": {
+        "description": "Application state delta.",
+        "items": {
+          "$ref": "#/components/schemas/EvalDeltaKeyValue"
+        },
+        "type": "array"
+      },
+      "StateProofFields": {
+        "description": "\\[sp\\] represents a state proof.\n\nDefinition:\ncrypto/stateproof/structs.go : StateProof",
+        "properties": {
+          "part-proofs": {
+            "$ref": "#/components/schemas/MerkleArrayProof"
+          },
+          "positions-to-reveal": {
+            "description": "\\[pr\\] Sequence of reveal positions.",
+            "items": {
+              "type": "integer",
+              "x-algorand-format": "uint64"
+            },
+            "type": "array"
+          },
+          "reveals": {
+            "description": "\\[r\\] Note that this is actually stored as a map[uint64] - Reveal in the actual msgp",
+            "items": {
+              "$ref": "#/components/schemas/StateProofReveal"
+            },
+            "type": "array"
+          },
+          "salt-version": {
+            "description": "\\[v\\] Salt version of the merkle signature.",
+            "type": "integer"
+          },
+          "sig-commit": {
+            "description": "\\[c\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "sig-proofs": {
+            "$ref": "#/components/schemas/MerkleArrayProof"
+          },
+          "signed-weight": {
+            "description": "\\[w\\]",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofParticipant": {
+        "properties": {
+          "verifier": {
+            "$ref": "#/components/schemas/StateProofVerifier"
+          },
+          "weight": {
+            "description": "\\[w\\]",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofReveal": {
+        "properties": {
+          "participant": {
+            "$ref": "#/components/schemas/StateProofParticipant"
+          },
+          "position": {
+            "description": "The position in the signature and participants arrays corresponding to this entry.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "sig-slot": {
+            "$ref": "#/components/schemas/StateProofSigSlot"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofSigSlot": {
+        "properties": {
+          "lower-sig-weight": {
+            "description": "\\[l\\] The total weight of signatures in the lower-numbered slots.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/StateProofSignature"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofSignature": {
+        "properties": {
+          "falcon-signature": {
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "merkle-array-index": {
+            "type": "integer",
+            "x-algorand-foramt": "uint64"
+          },
+          "proof": {
+            "$ref": "#/components/schemas/MerkleArrayProof"
+          },
+          "verifying-key": {
+            "description": "\\[vkey\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofTracking": {
+        "properties": {
+          "next-round": {
+            "description": "\\[n\\] Next round for which we will accept a state proof transaction.",
+            "type": "integer"
+          },
+          "online-total-weight": {
+            "description": "\\[t\\] The total number of microalgos held by the online accounts during the StateProof round.",
+            "type": "integer"
+          },
+          "type": {
+            "description": "State Proof Type. Note the raw object uses map with this as key.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "voters-commitment": {
+            "description": "\\[v\\] Root of a vector commitment containing online accounts that will help sign the proof.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "StateProofVerifier": {
+        "properties": {
+          "commitment": {
+            "description": "\\[cmt\\] Represents the root of the vector commitment tree.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "key-lifetime": {
+            "description": "\\[lf\\] Key lifetime.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "type": "object"
+      },
+      "StateSchema": {
+        "description": "Represents a \\[apls\\] local-state or \\[apgs\\] global-state schema. These schemas determine how much storage may be used in a local-state or global-state for an application. The more space used, the larger minimum balance must be maintained in the account holding the data.",
+        "properties": {
+          "num-byte-slice": {
+            "description": "Maximum number of TEAL byte slices that may be stored in the key/value store.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "num-uint": {
+            "description": "Maximum number of TEAL uints that may be stored in the key/value store.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "num-byte-slice",
+          "num-uint"
+        ],
+        "type": "object"
+      },
+      "TealKeyValue": {
+        "description": "Represents a key-value pair in an application store.",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/TealValue"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object"
+      },
+      "TealKeyValueStore": {
+        "description": "Represents a key-value store for use in an application.",
+        "items": {
+          "$ref": "#/components/schemas/TealKeyValue"
+        },
+        "type": "array"
+      },
+      "TealValue": {
+        "description": "Represents a TEAL value.",
+        "properties": {
+          "bytes": {
+            "description": "bytes value.",
+            "type": "string"
+          },
+          "type": {
+            "description": "type of the value. Value `1` refers to **bytes**, value `2` refers to **uint**",
+            "type": "integer"
+          },
+          "uint": {
+            "description": "uint value.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "required": [
+          "bytes",
+          "type",
+          "uint"
+        ],
+        "type": "object"
+      },
+      "Transaction": {
+        "description": "Contains all fields common to all transactions and serves as an envelope to all transactions type. Represents both regular and inner transactions.\n\nDefinition:\ndata/transactions/signedtxn.go : SignedTxn\ndata/transactions/transaction.go : Transaction\n",
+        "properties": {
+          "application-transaction": {
+            "$ref": "#/components/schemas/TransactionApplication"
+          },
+          "asset-config-transaction": {
+            "$ref": "#/components/schemas/TransactionAssetConfig"
+          },
+          "asset-freeze-transaction": {
+            "$ref": "#/components/schemas/TransactionAssetFreeze"
+          },
+          "asset-transfer-transaction": {
+            "$ref": "#/components/schemas/TransactionAssetTransfer"
+          },
+          "auth-addr": {
+            "description": "\\[sgnr\\] this is included with signed transactions when the signing address does not equal the sender. The backend can use this to ensure that auth addr is equal to the accounts auth addr.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "close-rewards": {
+            "description": "\\[rc\\] rewards applied to close-remainder-to account.",
+            "type": "integer"
+          },
+          "closing-amount": {
+            "description": "\\[ca\\] closing amount for transaction.",
+            "type": "integer"
+          },
+          "confirmed-round": {
+            "description": "Round when the transaction was confirmed.",
+            "type": "integer"
+          },
+          "created-application-index": {
+            "description": "Specifies an application index (ID) if an application was created with this transaction.",
+            "type": "integer"
+          },
+          "created-asset-index": {
+            "description": "Specifies an asset index (ID) if an asset was created with this transaction.",
+            "type": "integer"
+          },
+          "fee": {
+            "description": "\\[fee\\] Transaction fee.",
+            "type": "integer"
+          },
+          "first-valid": {
+            "description": "\\[fv\\] First valid round for this transaction.",
+            "type": "integer"
+          },
+          "genesis-hash": {
+            "description": "\\[gh\\] Hash of genesis block.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "genesis-id": {
+            "description": "\\[gen\\] genesis block ID.",
+            "type": "string"
+          },
+          "global-state-delta": {
+            "$ref": "#/components/schemas/StateDelta"
+          },
+          "group": {
+            "description": "\\[grp\\] Base64 encoded byte array of a sha512/256 digest. When present indicates that this transaction is part of a transaction group and the value is the sha512/256 hash of the transactions in that group.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "heartbeat-transaction": {
+            "$ref": "#/components/schemas/TransactionHeartbeat"
+          },
+          "id": {
+            "description": "Transaction ID",
+            "type": "string"
+          },
+          "inner-txns": {
+            "description": "Inner transactions produced by application execution.",
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            },
+            "type": "array"
+          },
+          "intra-round-offset": {
+            "description": "Offset into the round where this transaction was confirmed.",
+            "type": "integer"
+          },
+          "keyreg-transaction": {
+            "$ref": "#/components/schemas/TransactionKeyreg"
+          },
+          "last-valid": {
+            "description": "\\[lv\\] Last valid round for this transaction.",
+            "type": "integer"
+          },
+          "lease": {
+            "description": "\\[lx\\] Base64 encoded 32-byte array. Lease enforces mutual exclusion of transactions.  If this field is nonzero, then once the transaction is confirmed, it acquires the lease identified by the (Sender, Lease) pair of the transaction until the LastValid round passes.  While this transaction possesses the lease, no other transaction specifying this lease can be confirmed.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "local-state-delta": {
+            "description": "\\[ld\\] Local state key/value changes for the application being executed by this transaction.",
+            "items": {
+              "$ref": "#/components/schemas/AccountStateDelta"
+            },
+            "type": "array"
+          },
+          "logs": {
+            "description": "\\[lg\\] Logs for the application being executed by this transaction.",
+            "items": {
+              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "note": {
+            "description": "\\[note\\] Free form data.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "payment-transaction": {
+            "$ref": "#/components/schemas/TransactionPayment"
+          },
+          "receiver-rewards": {
+            "description": "\\[rr\\] rewards applied to receiver account.",
+            "type": "integer"
+          },
+          "rekey-to": {
+            "description": "\\[rekey\\] when included in a valid transaction, the accounts auth addr will be updated with this value and future signatures must be signed with the key represented by this address.",
+            "type": "string",
+            "x-algorand-format": "Address"
+          },
+          "round-time": {
+            "description": "Time when the block this transaction is in was confirmed.",
+            "type": "integer"
+          },
+          "sender": {
+            "description": "\\[snd\\] Sender's address.",
+            "type": "string"
+          },
+          "sender-rewards": {
+            "description": "\\[rs\\] rewards applied to sender account.",
+            "type": "integer"
+          },
+          "signature": {
+            "$ref": "#/components/schemas/TransactionSignature"
+          },
+          "state-proof-transaction": {
+            "$ref": "#/components/schemas/TransactionStateProof"
+          },
+          "tx-type": {
+            "description": "\\[type\\] Indicates what type of transaction this is. Different types have different fields.\n\nValid types, and where their fields are stored:\n* \\[pay\\] payment-transaction\n* \\[keyreg\\] keyreg-transaction\n* \\[acfg\\] asset-config-transaction\n* \\[axfer\\] asset-transfer-transaction\n* \\[afrz\\] asset-freeze-transaction\n* \\[appl\\] application-transaction\n* \\[stpf\\] state-proof-transaction\n* \\[hb\\] heartbeat-transaction",
+            "enum": [
+              "pay",
+              "keyreg",
+              "acfg",
+              "axfer",
+              "afrz",
+              "appl",
+              "stpf",
+              "hb"
+            ],
+            "type": "string",
+            "x-algorand-format": "tx-type-enum"
+          }
+        },
+        "required": [
+          "fee",
+          "first-valid",
+          "last-valid",
+          "sender",
+          "tx-type"
+        ],
+        "type": "object"
+      },
+      "TransactionApplication": {
+        "description": "Fields for application transactions.\n\nDefinition:\ndata/transactions/application.go : ApplicationCallTxnFields",
+        "properties": {
+          "access": {
+            "description": "\\[al\\] Access unifies `accounts`, `foreign-apps`, `foreign-assets`, and `box-references` under a single list. If access is non-empty, these lists must be empty. If access is empty, those lists may be non-empty.",
+            "items": {
+              "$ref": "#/components/schemas/ResourceRef"
+            },
+            "type": "array"
+          },
+          "accounts": {
+            "description": "\\[apat\\] List of accounts in addition to the sender that may be accessed from the application's approval-program and clear-state-program.",
+            "items": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "type": "array"
+          },
+          "application-args": {
+            "description": "\\[apaa\\] transaction specific arguments accessed from the application's approval-program and clear-state-program.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "application-id": {
+            "description": "\\[apid\\] ID of the application being configured or empty if creating.",
+            "type": "integer"
+          },
+          "approval-program": {
+            "description": "\\[apap\\] Logic executed for every application transaction, except when on-completion is set to \"clear\". It can read and write global state for the application, as well as account-specific local state. Approval programs may reject the transaction.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "box-references": {
+            "description": "\\[apbx\\] the boxes that can be accessed by this transaction (and others in the same group).",
+            "items": {
+              "$ref": "#/components/schemas/BoxReference"
+            },
+            "type": "array"
+          },
+          "clear-state-program": {
+            "description": "\\[apsu\\] Logic executed for application transactions with on-completion set to \"clear\". It can read and write global state for the application, as well as account-specific local state. Clear state programs cannot reject the transaction.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string",
+            "x-algorand-format": "TEALProgram"
+          },
+          "extra-program-pages": {
+            "description": "\\[epp\\] specifies the additional app program len requested in pages.",
+            "type": "integer"
+          },
+          "foreign-apps": {
+            "description": "\\[apfa\\] Lists the applications in addition to the application-id whose global states may be accessed by this application's approval-program and clear-state-program. The access is read-only.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "foreign-assets": {
+            "description": "\\[apas\\] lists the assets whose parameters may be accessed by this application's ApprovalProgram and ClearStateProgram. The access is read-only.",
+            "items": {
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "global-state-schema": {
+            "$ref": "#/components/schemas/StateSchema"
+          },
+          "local-state-schema": {
+            "$ref": "#/components/schemas/StateSchema"
+          },
+          "on-completion": {
+            "$ref": "#/components/schemas/OnCompletion"
+          },
+          "reject-version": {
+            "description": "\\[aprv\\] the lowest application version for which this transaction should immediately fail. 0 indicates that no version check should be performed.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "application-id",
+          "on-completion"
+        ],
+        "type": "object"
+      },
+      "TransactionAssetConfig": {
+        "description": "Fields for asset allocation, re-configuration, and destruction.\n\n\nA zero value for asset-id indicates asset creation.\nA zero value for the params indicates asset destruction.\n\nDefinition:\ndata/transactions/asset.go : AssetConfigTxnFields",
+        "properties": {
+          "asset-id": {
+            "description": "\\[xaid\\] ID of the asset being configured or empty if creating.",
+            "type": "integer"
+          },
+          "params": {
+            "$ref": "#/components/schemas/AssetParams"
+          }
+        },
+        "type": "object"
+      },
+      "TransactionAssetFreeze": {
+        "description": "Fields for an asset freeze transaction.\n\nDefinition:\ndata/transactions/asset.go : AssetFreezeTxnFields",
+        "properties": {
+          "address": {
+            "description": "\\[fadd\\] Address of the account whose asset is being frozen or thawed.",
+            "type": "string"
+          },
+          "asset-id": {
+            "description": "\\[faid\\] ID of the asset being frozen or thawed.",
+            "type": "integer"
+          },
+          "new-freeze-status": {
+            "description": "\\[afrz\\] The new freeze status.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "address",
+          "asset-id",
+          "new-freeze-status"
+        ],
+        "type": "object"
+      },
+      "TransactionAssetTransfer": {
+        "description": "Fields for an asset transfer transaction.\n\nDefinition:\ndata/transactions/asset.go : AssetTransferTxnFields",
+        "properties": {
+          "amount": {
+            "description": "\\[aamt\\] Amount of asset to transfer. A zero amount transferred to self allocates that asset in the account's Assets map.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "asset-id": {
+            "description": "\\[xaid\\] ID of the asset being transferred.",
+            "type": "integer"
+          },
+          "close-amount": {
+            "description": "Number of assets transferred to the close-to account as part of the transaction.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "close-to": {
+            "description": "\\[aclose\\] Indicates that the asset should be removed from the account's Assets map, and specifies where the remaining asset holdings should be transferred.  It's always valid to transfer remaining asset holdings to the creator account.",
+            "type": "string"
+          },
+          "receiver": {
+            "description": "\\[arcv\\] Recipient address of the transfer.",
+            "type": "string"
+          },
+          "sender": {
+            "description": "\\[asnd\\] The effective sender during a clawback transactions. If this is not a zero value, the real transaction sender must be the Clawback address from the AssetParams.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "asset-id",
+          "receiver"
+        ],
+        "type": "object"
+      },
+      "TransactionHeartbeat": {
+        "description": "Fields for a heartbeat transaction.\n\nDefinition:\ndata/transactions/heartbeat.go : HeartbeatTxnFields",
+        "properties": {
+          "hb-address": {
+            "description": "\\[hbad\\] HbAddress is the account this txn is proving onlineness for.",
+            "type": "string"
+          },
+          "hb-challenge-discount": {
+            "description": "\\[hbc\\] HbChallengeDiscount requests the challenge fee discount, reducing the required fee by one min fee. It is a request, not an assertion: it is granted only if HbAddress is actually under challenge.",
+            "type": "boolean"
+          },
+          "hb-key-dilution": {
+            "description": "\\[hbkd\\] HbKeyDilution must match HbAddress account's current KeyDilution.",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          },
+          "hb-proof": {
+            "$ref": "#/components/schemas/HbProofFields"
+          },
+          "hb-seed": {
+            "description": "\\[hbsd\\] HbSeed must be the block seed for the this transaction's firstValid block.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "hb-vote-id": {
+            "description": "\\[hbvid\\] HbVoteID must match the HbAddress account's current VoteID.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hb-address",
+          "hb-key-dilution",
+          "hb-proof",
+          "hb-seed",
+          "hb-vote-id"
+        ],
+        "type": "object"
+      },
+      "TransactionKeyreg": {
+        "description": "Fields for a keyreg transaction.\n\nDefinition:\ndata/transactions/keyreg.go : KeyregTxnFields",
+        "properties": {
+          "non-participation": {
+            "description": "\\[nonpart\\] Mark the account as participating or non-participating.",
+            "type": "boolean"
+          },
+          "selection-participation-key": {
+            "description": "\\[selkey\\] Public key used with the Verified Random Function (VRF) result during committee selection.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "state-proof-key": {
+            "description": "\\[sprfkey\\] State proof key used in key registration transactions.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "vote-first-valid": {
+            "description": "\\[votefst\\] First round this participation key is valid.",
+            "type": "integer"
+          },
+          "vote-key-dilution": {
+            "description": "\\[votekd\\] Number of subkeys in each batch of participation keys.",
+            "type": "integer"
+          },
+          "vote-last-valid": {
+            "description": "\\[votelst\\] Last round this participation key is valid.",
+            "type": "integer"
+          },
+          "vote-participation-key": {
+            "description": "\\[votekey\\] Participation public key used in key registration transactions.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TransactionPayment": {
+        "description": "Fields for a payment transaction.\n\nDefinition:\ndata/transactions/payment.go : PaymentTxnFields",
+        "properties": {
+          "amount": {
+            "description": "\\[amt\\] number of MicroAlgos intended to be transferred.",
+            "type": "integer"
+          },
+          "close-amount": {
+            "description": "Number of MicroAlgos that were sent to the close-remainder-to address when closing the sender account.",
+            "type": "integer"
+          },
+          "close-remainder-to": {
+            "description": "\\[close\\] when set, indicates that the sending account should be closed and all remaining funds be transferred to this address.",
+            "type": "string"
+          },
+          "receiver": {
+            "description": "\\[rcv\\] receiver's address.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount",
+          "receiver"
+        ],
+        "type": "object"
+      },
+      "TransactionSignature": {
+        "description": "Validation signature associated with some data. Only one of the signatures should be provided.",
+        "properties": {
+          "logicsig": {
+            "$ref": "#/components/schemas/TransactionSignatureLogicsig"
+          },
+          "multisig": {
+            "$ref": "#/components/schemas/TransactionSignatureMultisig"
+          },
+          "pqsig": {
+            "$ref": "#/components/schemas/TransactionSignaturePQsig"
+          },
+          "sig": {
+            "description": "\\[sig\\] Standard ed25519 signature.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TransactionSignatureLogicsig": {
+        "description": "\\[lsig\\] Programatic transaction signature.\n\nDefinition:\ndata/transactions/logicsig.go",
+        "properties": {
+          "args": {
+            "description": "\\[arg\\] Logic arguments, base64 encoded.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "logic": {
+            "description": "\\[l\\] Program signed by a signature or multi signature, or hashed to be the address of ana ccount. Base64 encoded TEAL program.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "logic-multisig-signature": {
+            "$ref": "#/components/schemas/TransactionSignatureMultisig"
+          },
+          "multisig-signature": {
+            "$ref": "#/components/schemas/TransactionSignatureMultisig"
+          },
+          "pqsig": {
+            "$ref": "#/components/schemas/TransactionSignaturePQsig"
+          },
+          "signature": {
+            "description": "\\[sig\\] ed25519 signature.",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "logic"
+        ],
+        "type": "object"
+      },
+      "TransactionSignatureMultisig": {
+        "description": "structure holding multiple subsignatures.\n\nDefinition:\ncrypto/multisig.go : MultisigSig",
+        "properties": {
+          "subsignature": {
+            "description": "\\[subsig\\] holds pairs of public key and signatures.",
+            "items": {
+              "$ref": "#/components/schemas/TransactionSignatureMultisigSubsignature"
+            },
+            "type": "array"
+          },
+          "threshold": {
+            "description": "\\[thr\\]",
+            "type": "integer"
+          },
+          "version": {
+            "description": "\\[v\\]",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "TransactionSignatureMultisigSubsignature": {
+        "properties": {
+          "public-key": {
+            "description": "\\[pk\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "signature": {
+            "description": "\\[s\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TransactionSignaturePQsig": {
+        "description": "structure holding a post-quantum signature.\n\nDefinition:\ntransactions/pqsig.go : PQSig",
+        "properties": {
+          "public-key": {
+            "description": "\\[pk\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          },
+          "salt": {
+            "description": "\\[slt\\] a single byte, added to ensure the hashed address is not an Ed25519 curve point",
+            "type": "integer"
+          },
+          "scheme": {
+            "description": "\\[sch\\] identifies the internal signature scheme.",
+            "type": "string"
+          },
+          "signature": {
+            "description": "\\[sig\\]",
+            "format": "byte",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "public-key",
+          "scheme",
+          "signature"
+        ],
+        "type": "object"
+      },
+      "TransactionStateProof": {
+        "description": "Fields for a state proof transaction. \n\nDefinition:\ndata/transactions/stateproof.go : StateProofTxnFields",
+        "properties": {
+          "message": {
+            "$ref": "#/components/schemas/IndexerStateProofMessage"
+          },
+          "state-proof": {
+            "$ref": "#/components/schemas/StateProofFields"
+          },
+          "state-proof-type": {
+            "description": "\\[sptype\\] Type of the state proof. Integer representing an entry defined in protocol/stateproof.go",
+            "type": "integer",
+            "x-algorand-format": "uint64"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "name": "Algorand",
+      "url": "https://www.algorand.com/get-in-touch/contact"
+    },
+    "description": "`algorand-indexer` serves searchable historical ledger data — accounts,\nassets, applications, blocks and transactions — including the records an\n`algod` node no longer holds locally.\n\nThe daemon serves its API from the host:port given by `--server`, default\nport `8980`.\n\nEvery endpoint is listed in the sidebar under **indexer** → the tag groups, one page per\noperation.\n\nSpec downloads (OAS2 and OAS3) and ready-to-run Scalar, Swagger and Postman\ncollections are on the [REST API overview](/reference/rest-api/overview).",
+    "title": "Indexer REST API",
+    "version": "2.0"
+  },
+  "openapi": "3.0.1",
+  "paths": {
+    "/health": {
+      "get": {
+        "operationId": "makeHealthCheck",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthCheck"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "default": {
+            "content": {},
+            "description": "Unknown Error"
+          }
+        },
+        "summary": "Returns 200 if healthy.",
+        "tags": [
+          "common"
+        ]
+      }
+    },
+    "/v2/accounts": {
+      "get": {
+        "description": "Search for accounts.",
+        "operationId": "searchForAccounts",
+        "parameters": [
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-greater-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Exclude additional items such as asset holdings, application local data stored for this account, asset parameters created by this account, and application parameters created by this account.",
+            "explode": false,
+            "in": "query",
+            "name": "exclude",
+            "schema": {
+              "items": {
+                "enum": [
+                  "all",
+                  "assets",
+                  "created-assets",
+                  "apps-local-state",
+                  "created-apps",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-less-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include accounts configured to use this spending key.",
+            "in": "query",
+            "name": "auth-addr",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "x-algorand-format": "Address"
+          },
+          {
+            "description": "Include results for the specified round. For performance reasons, this parameter may be disabled on some configurations. Using application-id or asset-id filters will return both creator and opt-in accounts. Filtering by include-all will return creator and opt-in accounts for deleted assets and accounts. Non-opt-in managers are not included in the results when asset-id is used.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Application ID",
+            "in": "query",
+            "name": "application-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "When this is set to true, return only accounts whose participation status is currently online.",
+            "in": "query",
+            "name": "online-only",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "accounts": {
+                      "items": {
+                        "$ref": "#/components/schemas/Account"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "accounts",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}": {
+      "get": {
+        "description": "Lookup account information.",
+        "operationId": "lookupAccountByID",
+        "parameters": [
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results for the specified round.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Exclude additional items such as asset holdings, application local data stored for this account, asset parameters created by this account, and application parameters created by this account.",
+            "explode": false,
+            "in": "query",
+            "name": "exclude",
+            "schema": {
+              "items": {
+                "enum": [
+                  "all",
+                  "assets",
+                  "created-assets",
+                  "apps-local-state",
+                  "created-apps",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "account": {
+                      "$ref": "#/components/schemas/Account"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "account",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}/apps-local-state": {
+      "get": {
+        "description": "Lookup an account's asset holdings, optionally for a specific ID.",
+        "operationId": "lookupAccountAppLocalStates",
+        "parameters": [
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Application ID",
+            "in": "query",
+            "name": "application-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "apps-local-states": {
+                      "items": {
+                        "$ref": "#/components/schemas/ApplicationLocalState"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "apps-local-states",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}/assets": {
+      "get": {
+        "description": "Lookup an account's asset holdings, optionally for a specific ID.",
+        "operationId": "lookupAccountAssets",
+        "parameters": [
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "assets": {
+                      "items": {
+                        "$ref": "#/components/schemas/AssetHolding"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "assets",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}/created-applications": {
+      "get": {
+        "description": "Lookup an account's created application parameters, optionally for a specific ID.",
+        "operationId": "lookupAccountCreatedApplications",
+        "parameters": [
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Application ID",
+            "in": "query",
+            "name": "application-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "applications": {
+                      "items": {
+                        "$ref": "#/components/schemas/Application"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applications",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}/created-assets": {
+      "get": {
+        "description": "Lookup an account's created asset parameters, optionally for a specific ID.",
+        "operationId": "lookupAccountCreatedAssets",
+        "parameters": [
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "assets": {
+                      "items": {
+                        "$ref": "#/components/schemas/Asset"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "assets",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/accounts/{account-id}/transactions": {
+      "get": {
+        "description": "Lookup account transactions. Transactions are returned newest to oldest.",
+        "operationId": "lookupAccountTransactions",
+        "parameters": [
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies a prefix which must be contained in the note field.",
+            "in": "query",
+            "name": "note-prefix",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "base64"
+            },
+            "x-algorand-format": "base64"
+          },
+          {
+            "in": "query",
+            "name": "tx-type",
+            "schema": {
+              "enum": [
+                "pay",
+                "keyreg",
+                "acfg",
+                "axfer",
+                "afrz",
+                "appl",
+                "stpf",
+                "hb"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "SigType filters just results using the specified type of signature:\n* sig - Standard\n* msig - MultiSig\n* lsig - LogicSig\n* pqsig - Post-Quantum",
+            "in": "query",
+            "name": "sig-type",
+            "schema": {
+              "enum": [
+                "sig",
+                "msig",
+                "lsig",
+                "pqsig"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lookup the specific transaction by ID.",
+            "in": "query",
+            "name": "txid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results for the specified round.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or after the specified min-round.",
+            "in": "query",
+            "name": "min-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or before the specified max-round.",
+            "in": "query",
+            "name": "max-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results before the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "before-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Include results after the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "after-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-greater-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-less-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "account string",
+            "in": "path",
+            "name": "account-id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results which include the rekey-to field.",
+            "in": "query",
+            "name": "rekey-to",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    },
+                    "transactions": {
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "current-round",
+                    "transactions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/applications": {
+      "get": {
+        "description": "Search for applications",
+        "operationId": "searchForApplications",
+        "parameters": [
+          {
+            "description": "Application ID",
+            "in": "query",
+            "name": "application-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter just applications with the given creator address.",
+            "in": "query",
+            "name": "creator",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "applications": {
+                      "items": {
+                        "$ref": "#/components/schemas/Application"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "applications",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}": {
+      "get": {
+        "description": "Lookup application.",
+        "operationId": "lookupApplicationByID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "application": {
+                      "$ref": "#/components/schemas/Application"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}/box": {
+      "get": {
+        "description": "Given an application ID and box name, returns base64 encoded box name and value. Box names must be in the goal app call arg form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, encode base 64 and use 'b64' prefix as in 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.",
+        "operationId": "lookupApplicationBoxByIDAndName",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "A box name in goal-arg form 'encoding:value'. For ints, use the form 'int:1234'. For raw bytes, use the form 'b64:A=='. For printable strings, use the form 'str:hello'. For addresses, use the form 'addr:XYZ...'.",
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Box"
+                }
+              }
+            },
+            "description": "Box information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "summary": "Get box information for a given application.",
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}/boxes": {
+      "get": {
+        "description": "Given an application ID, returns the box names of that application sorted lexicographically.",
+        "operationId": "searchForApplicationBoxes",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include additional items in the response. Use `values` to include box values. Multiple values can be comma-separated.",
+            "explode": false,
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "items": {
+                "enum": [
+                  "values"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "application-id": {
+                      "description": "\\[appidx\\] application index.",
+                      "type": "integer"
+                    },
+                    "boxes": {
+                      "items": {
+                        "$ref": "#/components/schemas/BoxDescriptor"
+                      },
+                      "type": "array"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    },
+                    "round": {
+                      "description": "The round for which this information is relevant.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "application-id",
+                    "boxes"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Box names of an application"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "summary": "Get box names for a given application.",
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/applications/{application-id}/logs": {
+      "get": {
+        "description": "Lookup application logs.",
+        "operationId": "lookupApplicationLogsByID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "application-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lookup the specific transaction by ID.",
+            "in": "query",
+            "name": "txid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results at or after the specified min-round.",
+            "in": "query",
+            "name": "min-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or before the specified max-round.",
+            "in": "query",
+            "name": "max-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only include transactions with this sender address.",
+            "in": "query",
+            "name": "sender-address",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "x-algorand-format": "Address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "application-id": {
+                      "description": "\\[appidx\\] application index.",
+                      "type": "integer"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "log-data": {
+                      "items": {
+                        "$ref": "#/components/schemas/ApplicationLogData"
+                      },
+                      "type": "array"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "application-id",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/assets": {
+      "get": {
+        "description": "Search for assets.",
+        "operationId": "searchForAssets",
+        "parameters": [
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter just assets with the given creator address.",
+            "in": "query",
+            "name": "creator",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter just assets with the given name.",
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter just assets with the given unit.",
+            "in": "query",
+            "name": "unit",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "assets": {
+                      "items": {
+                        "$ref": "#/components/schemas/Asset"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "assets",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/assets/{asset-id}": {
+      "get": {
+        "description": "Lookup asset information.",
+        "operationId": "lookupAssetByID",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "asset-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "asset": {
+                      "$ref": "#/components/schemas/Asset"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "asset",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/assets/{asset-id}/balances": {
+      "get": {
+        "description": "Lookup the list of accounts who hold this asset ",
+        "operationId": "lookupAssetBalances",
+        "parameters": [
+          {
+            "description": "Include all items including closed accounts, deleted applications, destroyed assets, opted-out asset holdings, and closed-out application localstates.",
+            "in": "query",
+            "name": "include-all",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-greater-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-less-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "balances": {
+                      "items": {
+                        "$ref": "#/components/schemas/MiniAssetHolding"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "balances",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/assets/{asset-id}/transactions": {
+      "get": {
+        "description": "Lookup transactions for an asset. Transactions are returned oldest to newest.",
+        "operationId": "lookupAssetTransactions",
+        "parameters": [
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies a prefix which must be contained in the note field.",
+            "in": "query",
+            "name": "note-prefix",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "base64"
+            },
+            "x-algorand-format": "base64"
+          },
+          {
+            "in": "query",
+            "name": "tx-type",
+            "schema": {
+              "enum": [
+                "pay",
+                "keyreg",
+                "acfg",
+                "axfer",
+                "afrz",
+                "appl",
+                "stpf",
+                "hb"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "SigType filters just results using the specified type of signature:\n* sig - Standard\n* msig - MultiSig\n* lsig - LogicSig\n* pqsig - Post-Quantum",
+            "in": "query",
+            "name": "sig-type",
+            "schema": {
+              "enum": [
+                "sig",
+                "msig",
+                "lsig",
+                "pqsig"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lookup the specific transaction by ID.",
+            "in": "query",
+            "name": "txid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results for the specified round.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or after the specified min-round.",
+            "in": "query",
+            "name": "min-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or before the specified max-round.",
+            "in": "query",
+            "name": "max-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results before the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "before-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Include results after the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "after-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-greater-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-less-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only include transactions with this address in one of the transaction fields.",
+            "in": "query",
+            "name": "address",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "x-algorand-format": "Address"
+          },
+          {
+            "description": "Combine with the address parameter to define what type of address to search for.",
+            "in": "query",
+            "name": "address-role",
+            "schema": {
+              "enum": [
+                "sender",
+                "receiver",
+                "freeze-target"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Combine with address and address-role parameters to define what type of address to search for. The close to fields are normally treated as a receiver, if you would like to exclude them set this parameter to true.",
+            "in": "query",
+            "name": "exclude-close-to",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "path",
+            "name": "asset-id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results which include the rekey-to field.",
+            "in": "query",
+            "name": "rekey-to",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    },
+                    "transactions": {
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "current-round",
+                    "transactions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/block-headers": {
+      "get": {
+        "description": "Search for block headers. Block headers are returned in ascending round order. Transactions are not included in the output.",
+        "operationId": "searchForBlockHeaders",
+        "parameters": [
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results at or after the specified min-round.",
+            "in": "query",
+            "name": "min-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or before the specified max-round.",
+            "in": "query",
+            "name": "max-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results before the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "before-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Include results after the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "after-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Accounts marked as proposer in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+            "explode": false,
+            "in": "query",
+            "name": "proposers",
+            "schema": {
+              "items": {
+                "type": "string",
+                "x-algorand-format": "Address"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Accounts marked as expired in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+            "explode": false,
+            "in": "query",
+            "name": "expired",
+            "schema": {
+              "items": {
+                "type": "string",
+                "x-algorand-format": "Address"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Accounts marked as absent in the block header's participation updates. This parameter accepts a comma separated list of addresses.",
+            "explode": false,
+            "in": "query",
+            "name": "absent",
+            "schema": {
+              "items": {
+                "type": "string",
+                "x-algorand-format": "Address"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blocks": {
+                      "items": {
+                        "$ref": "#/components/schemas/Block"
+                      },
+                      "type": "array"
+                    },
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "blocks",
+                    "current-round"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/blocks/{round-number}": {
+      "get": {
+        "description": "Lookup block.",
+        "operationId": "lookupBlock",
+        "parameters": [
+          {
+            "description": "Round number",
+            "in": "path",
+            "name": "round-number",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Header only flag. When this is set to true, returned block does not contain the transactions",
+            "in": "query",
+            "name": "header-only",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Block"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    },
+    "/v2/transactions": {
+      "get": {
+        "description": "Search for transactions. Transactions are returned oldest to newest unless the address parameter is used, in which case results are returned newest to oldest.",
+        "operationId": "searchForTransactions",
+        "parameters": [
+          {
+            "description": "Maximum number of results to return. There could be additional pages even if the limit is not reached.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The next page of results. Use the next token provided by the previous results.",
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Specifies a prefix which must be contained in the note field.",
+            "in": "query",
+            "name": "note-prefix",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "base64"
+            },
+            "x-algorand-format": "base64"
+          },
+          {
+            "in": "query",
+            "name": "tx-type",
+            "schema": {
+              "enum": [
+                "pay",
+                "keyreg",
+                "acfg",
+                "axfer",
+                "afrz",
+                "appl",
+                "stpf",
+                "hb"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "SigType filters just results using the specified type of signature:\n* sig - Standard\n* msig - MultiSig\n* lsig - LogicSig\n* pqsig - Post-Quantum",
+            "in": "query",
+            "name": "sig-type",
+            "schema": {
+              "enum": [
+                "sig",
+                "msig",
+                "lsig",
+                "pqsig"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Lookup transactions by group ID. This field must be base64-encoded, and afterwards, base64 characters that are URL-unsafe (i.e. =, /, +) must be URL-encoded",
+            "in": "query",
+            "name": "group-id",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "base64"
+            },
+            "x-algorand-format": "base64"
+          },
+          {
+            "description": "Lookup the specific transaction by ID.",
+            "in": "query",
+            "name": "txid",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include results for the specified round.",
+            "in": "query",
+            "name": "round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or after the specified min-round.",
+            "in": "query",
+            "name": "min-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results at or before the specified max-round.",
+            "in": "query",
+            "name": "max-round",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Asset ID",
+            "in": "query",
+            "name": "asset-id",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Include results before the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "before-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Include results after the given time. Must be an RFC 3339 formatted string.",
+            "in": "query",
+            "name": "after-time",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "x-algorand-format": "RFC3339 String"
+            },
+            "x-algorand-format": "RFC3339 String"
+          },
+          {
+            "description": "Results should have an amount greater than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-greater-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Results should have an amount less than this value. MicroAlgos are the default currency unless an asset-id is provided, in which case the asset will be used.",
+            "in": "query",
+            "name": "currency-less-than",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only include transactions with this address in one of the transaction fields.",
+            "in": "query",
+            "name": "address",
+            "schema": {
+              "type": "string",
+              "x-algorand-format": "Address"
+            },
+            "x-algorand-format": "Address"
+          },
+          {
+            "description": "Combine with the address parameter to define what type of address to search for.",
+            "in": "query",
+            "name": "address-role",
+            "schema": {
+              "enum": [
+                "sender",
+                "receiver",
+                "freeze-target"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Combine with address and address-role parameters to define what type of address to search for. The close to fields are normally treated as a receiver, if you would like to exclude them set this parameter to true.",
+            "in": "query",
+            "name": "exclude-close-to",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Include results which include the rekey-to field.",
+            "in": "query",
+            "name": "rekey-to",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Application ID",
+            "in": "query",
+            "name": "application-id",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "next-token": {
+                      "description": "Used for pagination, when making another request provide this token with the next parameter.",
+                      "type": "string"
+                    },
+                    "transactions": {
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "current-round",
+                    "transactions"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v2/transactions/{txid}": {
+      "get": {
+        "description": "Lookup a single transaction.",
+        "operationId": "lookupTransaction",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "txid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current-round": {
+                      "description": "Round at which the results were computed.",
+                      "type": "integer"
+                    },
+                    "transaction": {
+                      "$ref": "#/components/schemas/Transaction"
+                    }
+                  },
+                  "required": [
+                    "current-round",
+                    "transaction"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "(empty)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Response for errors"
+          }
+        },
+        "tags": [
+          "lookup"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://example.com/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "common"
+    },
+    {
+      "name": "lookup"
+    },
+    {
+      "name": "search"
+    }
+  ],
+  "x-original-swagger-version": "2.0"
+}

--- a/openapi/kmd.json
+++ b/openapi/kmd.json
@@ -1,0 +1,1701 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "http"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "`kmd` is the Algorand key management daemon. It keeps wallets and private\nkeys in a separate process from `algod` and signs transactions on request, so\nkeys never pass through the node itself.\n\nEvery endpoint is listed in the sidebar under **kmd** → **Operations**, one page per\noperation.\n\nSpec downloads (OAS2 and OAS3) and ready-to-run Scalar, Swagger and Postman\ncollections are on the [REST API overview](/reference/rest-api/overview).",
+    "title": "KMD REST API",
+    "contact": {
+      "email": "contact@algorand.com"
+    },
+    "version": "0.0.1"
+  },
+  "host": "localhost",
+  "basePath": "/",
+  "paths": {
+    "/swagger.json": {
+      "get": {
+        "description": "Returns the entire swagger spec in json.",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "summary": "Gets the current swagger spec.",
+        "operationId": "SwaggerHandler",
+        "responses": {
+          "200": {
+            "description": "The current swagger spec",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "description": "Unknown Error"
+          }
+        }
+      }
+    },
+    "/v1/key": {
+      "post": {
+        "description": "Generates the next key in the deterministic key sequence (as determined by the master derivation key) and adds it to the wallet, returning the public key.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Generate a key",
+        "operationId": "GenerateKey",
+        "parameters": [
+          {
+            "name": "Generate Key Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/GenerateKeyResponse"
+          }
+        }
+      },
+      "delete": {
+        "description": "Deletes the key with the passed public key from the wallet.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Delete a key",
+        "operationId": "DeleteKey",
+        "parameters": [
+          {
+            "name": "Delete Key Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeleteKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/DeleteKeyResponse"
+          }
+        }
+      }
+    },
+    "/v1/key/export": {
+      "post": {
+        "description": "Export the secret key associated with the passed public key.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Export a key",
+        "operationId": "ExportKey",
+        "parameters": [
+          {
+            "name": "Export Key Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExportKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ExportKeyResponse"
+          }
+        }
+      }
+    },
+    "/v1/key/import": {
+      "post": {
+        "description": "Import an externally generated key into the wallet. Note that if you wish to back up the imported key, you must do so by backing up the entire wallet database, because imported keys were not derived from the wallet's master derivation key.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Import a key",
+        "operationId": "ImportKey",
+        "parameters": [
+          {
+            "name": "Import Key Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ImportKeyResponse"
+          }
+        }
+      }
+    },
+    "/v1/key/list": {
+      "post": {
+        "description": "Lists all of the public keys in this wallet. All of them have a stored private key.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "List keys in wallet",
+        "operationId": "ListKeysInWallet",
+        "parameters": [
+          {
+            "name": "List Keys Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ListKeysRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ListKeysResponse"
+          }
+        }
+      }
+    },
+    "/v1/master-key/export": {
+      "post": {
+        "description": "Export the master derivation key from the wallet. This key is a master \"backup\" key for the underlying wallet. With it, you can regenerate all of the wallets that have been generated with this wallet's `POST /v1/key` endpoint. This key will not allow you to recover keys imported from other wallets, however.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Export the master derivation key from a wallet",
+        "operationId": "ExportMasterKey",
+        "parameters": [
+          {
+            "name": "Export Master Key Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExportMasterKeyRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ExportMasterKeyResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig": {
+      "delete": {
+        "description": "Deletes multisig preimage information for the passed address from the wallet.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Delete a multisig",
+        "operationId": "DeleteMultisig",
+        "parameters": [
+          {
+            "name": "Delete Multisig Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DeleteMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/DeleteMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig/export": {
+      "post": {
+        "description": "Given a multisig address whose preimage this wallet stores, returns the information used to generate the address, including public keys, threshold, and multisig version.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Export multisig address metadata",
+        "operationId": "ExportMultisig",
+        "parameters": [
+          {
+            "name": "Export Multisig Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExportMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ExportMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig/import": {
+      "post": {
+        "description": "Generates a multisig account from the passed public keys array and multisig metadata, and stores all of this in the wallet.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Import a multisig account",
+        "operationId": "ImportMultisig",
+        "parameters": [
+          {
+            "name": "Import Multisig Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ImportMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ImportMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig/list": {
+      "post": {
+        "description": "Lists all of the multisig accounts whose preimages this wallet stores",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "List multisig accounts",
+        "operationId": "ListMultisg",
+        "parameters": [
+          {
+            "name": "List Multisig Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ListMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ListMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig/sign": {
+      "post": {
+        "description": "Start a multisig signature, or add a signature to a partially completed multisig signature object.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Sign a multisig transaction",
+        "operationId": "SignMultisigTransaction",
+        "parameters": [
+          {
+            "name": "Sign Multisig Transaction Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/SignMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/multisig/signprogram": {
+      "post": {
+        "description": "Start a multisig signature, or add a signature to a partially completed multisig signature object.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Sign a program for a multisig account",
+        "operationId": "SignMultisigProgram",
+        "parameters": [
+          {
+            "name": "Sign Multisig Program Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignProgramMultisigRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/SignProgramMultisigResponse"
+          }
+        }
+      }
+    },
+    "/v1/program/sign": {
+      "post": {
+        "description": "Signs the passed program with a key from the wallet, determined by the account named in the request.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Sign program",
+        "operationId": "SignProgram",
+        "parameters": [
+          {
+            "name": "Sign Program Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignProgramRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/SignProgramResponse"
+          }
+        }
+      }
+    },
+    "/v1/transaction/sign": {
+      "post": {
+        "description": "Signs the passed transaction with a key from the wallet, determined by the sender encoded in the transaction.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Sign a transaction",
+        "operationId": "SignTransaction",
+        "parameters": [
+          {
+            "name": "Sign Transaction Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignTransactionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/SignTransactionResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet": {
+      "post": {
+        "description": "Create a new wallet (collection of keys) with the given parameters.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Create a wallet",
+        "operationId": "CreateWallet",
+        "parameters": [
+          {
+            "name": "Create Wallet Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateWalletRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/CreateWalletResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet/info": {
+      "post": {
+        "description": "Returns information about the wallet associated with the passed wallet handle token. Additionally returns expiration information about the token itself.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Get wallet info",
+        "operationId": "GetWalletInfo",
+        "parameters": [
+          {
+            "name": "Get Wallet Info Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WalletInfoRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/WalletInfoResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet/init": {
+      "post": {
+        "description": "Unlock the wallet and return a wallet handle token that can be used for subsequent operations. These tokens expire periodically and must be renewed. You can `POST` the token to `/v1/wallet/info` to see how much time remains until expiration, and renew it with `/v1/wallet/renew`. When you're done, you can invalidate the token with `/v1/wallet/release`.\n",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Initialize a wallet handle token",
+        "operationId": "InitWalletHandleToken",
+        "parameters": [
+          {
+            "name": "Initialize Wallet Handle Token Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InitWalletHandleTokenRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/InitWalletHandleTokenResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet/release": {
+      "post": {
+        "description": "Invalidate the passed wallet handle token, making it invalid for use in subsequent requests.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Release a wallet handle token",
+        "operationId": "ReleaseWalletHandleToken",
+        "parameters": [
+          {
+            "name": "Release Wallet Handle Token Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReleaseWalletHandleTokenRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ReleaseWalletHandleTokenResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet/rename": {
+      "post": {
+        "description": "Rename the underlying wallet to something else",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Rename a wallet",
+        "operationId": "RenameWallet",
+        "parameters": [
+          {
+            "name": "Rename Wallet Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenameWalletRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/RenameWalletResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallet/renew": {
+      "post": {
+        "description": "Renew a wallet handle token, increasing its expiration duration to its initial value",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Renew a wallet handle token",
+        "operationId": "RenewWalletHandleToken",
+        "parameters": [
+          {
+            "name": "Renew Wallet Handle Token Request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RenewWalletHandleTokenRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/RenewWalletHandleTokenResponse"
+          }
+        }
+      }
+    },
+    "/v1/wallets": {
+      "get": {
+        "description": "Lists all of the wallets that kmd is aware of.",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "List wallets",
+        "operationId": "ListWallets",
+        "parameters": [
+          {
+            "name": "List Wallet Request",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ListWalletsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ListWalletsResponse"
+          }
+        }
+      }
+    },
+    "/versions": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Retrieves the current version",
+        "operationId": "GetVersion",
+        "parameters": [
+          {
+            "name": "Versions Request",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/VersionsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/VersionsResponse"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "APIV1DELETEKeyResponse": {
+      "description": "APIV1DELETEKeyResponse is the response to `DELETE /v1/key`\nfriendly:DeleteKeyResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1DELETEMultisigResponse": {
+      "description": "APIV1DELETEMultisigResponse is the response to POST /v1/multisig/delete`\nfriendly:DeleteMultisigResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1GETWalletsResponse": {
+      "description": "APIV1GETWalletsResponse is the response to `GET /v1/wallets`\nfriendly:ListWalletsResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/APIV1Wallet"
+          },
+          "x-go-name": "Wallets"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTKeyExportResponse": {
+      "description": "APIV1POSTKeyExportResponse is the response to `POST /v1/key/export`\nfriendly:ExportKeyResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "private_key": {
+          "$ref": "#/definitions/PrivateKey"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTKeyImportResponse": {
+      "description": "APIV1POSTKeyImportResponse is the response to `POST /v1/key/import`\nfriendly:ImportKeyResponse",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTKeyListResponse": {
+      "description": "APIV1POSTKeyListResponse is the response to `POST /v1/key/list`\nfriendly:ListKeysResponse",
+      "type": "object",
+      "properties": {
+        "addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Addresses"
+        },
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTKeyResponse": {
+      "description": "APIV1POSTKeyResponse is the response to `POST /v1/key`\nfriendly:GenerateKeyResponse",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMasterKeyExportResponse": {
+      "description": "APIV1POSTMasterKeyExportResponse is the response to `POST /v1/master-key/export`\nfriendly:ExportMasterKeyResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "master_derivation_key": {
+          "$ref": "#/definitions/MasterDerivationKey"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMultisigExportResponse": {
+      "description": "APIV1POSTMultisigExportResponse is the response to `POST /v1/multisig/export`\nfriendly:ExportMultisigResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "multisig_version": {
+          "type": "integer",
+          "format": "uint8",
+          "x-go-name": "Version"
+        },
+        "pks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicKey"
+          },
+          "x-go-name": "PKs"
+        },
+        "threshold": {
+          "type": "integer",
+          "format": "uint8",
+          "x-go-name": "Threshold"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMultisigImportResponse": {
+      "description": "APIV1POSTMultisigImportResponse is the response to `POST /v1/multisig/import`\nfriendly:ImportMultisigResponse",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMultisigListResponse": {
+      "description": "APIV1POSTMultisigListResponse is the response to `POST /v1/multisig/list`\nfriendly:ListMultisigResponse",
+      "type": "object",
+      "properties": {
+        "addresses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Addresses"
+        },
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMultisigProgramSignResponse": {
+      "description": "APIV1POSTMultisigProgramSignResponse is the response to `POST /v1/multisig/signdata`\nfriendly:SignProgramMultisigResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "multisig": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Multisig"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTMultisigTransactionSignResponse": {
+      "description": "APIV1POSTMultisigTransactionSignResponse is the response to `POST /v1/multisig/sign`\nfriendly:SignMultisigResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "multisig": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Multisig"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTProgramSignResponse": {
+      "description": "APIV1POSTProgramSignResponse is the response to `POST /v1/data/sign`\nfriendly:SignProgramResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "sig": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Signature"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTTransactionSignResponse": {
+      "description": "APIV1POSTTransactionSignResponse is the response to `POST /v1/transaction/sign`\nfriendly:SignTransactionResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "signed_transaction": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "SignedTransaction"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletInfoResponse": {
+      "description": "APIV1POSTWalletInfoResponse is the response to `POST /v1/wallet/info`\nfriendly:WalletInfoResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallet_handle": {
+          "$ref": "#/definitions/APIV1WalletHandle"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletInitResponse": {
+      "description": "APIV1POSTWalletInitResponse is the response to `POST /v1/wallet/init`\nfriendly:InitWalletHandleTokenResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletReleaseResponse": {
+      "description": "APIV1POSTWalletReleaseResponse is the response to `POST /v1/wallet/release`\nfriendly:ReleaseWalletHandleTokenResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletRenameResponse": {
+      "description": "APIV1POSTWalletRenameResponse is the response to `POST /v1/wallet/rename`\nfriendly:RenameWalletResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallet": {
+          "$ref": "#/definitions/APIV1Wallet"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletRenewResponse": {
+      "description": "APIV1POSTWalletRenewResponse is the response to `POST /v1/wallet/renew`\nfriendly:RenewWalletHandleTokenResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallet_handle": {
+          "$ref": "#/definitions/APIV1WalletHandle"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1POSTWalletResponse": {
+      "description": "APIV1POSTWalletResponse is the response to `POST /v1/wallet`\nfriendly:CreateWalletResponse",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "boolean",
+          "x-go-name": "Error"
+        },
+        "message": {
+          "type": "string",
+          "x-go-name": "Message"
+        },
+        "wallet": {
+          "$ref": "#/definitions/APIV1Wallet"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1Wallet": {
+      "description": "APIV1Wallet is the API's representation of a wallet",
+      "type": "object",
+      "properties": {
+        "driver_name": {
+          "type": "string",
+          "x-go-name": "DriverName"
+        },
+        "driver_version": {
+          "type": "integer",
+          "format": "uint32",
+          "x-go-name": "DriverVersion"
+        },
+        "id": {
+          "type": "string",
+          "x-go-name": "ID"
+        },
+        "mnemonic_ux": {
+          "type": "boolean",
+          "x-go-name": "SupportsMnemonicUX"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "supported_txs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TxType"
+          },
+          "x-go-name": "SupportedTransactions"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "APIV1WalletHandle": {
+      "description": "APIV1WalletHandle includes the wallet the handle corresponds to\nand the number of number of seconds to expiration",
+      "type": "object",
+      "properties": {
+        "expires_seconds": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ExpiresSeconds"
+        },
+        "wallet": {
+          "$ref": "#/definitions/APIV1Wallet"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "CreateWalletRequest": {
+      "description": "APIV1POSTWalletRequest is the request for `POST /v1/wallet`",
+      "type": "object",
+      "properties": {
+        "master_derivation_key": {
+          "$ref": "#/definitions/MasterDerivationKey"
+        },
+        "wallet_driver_name": {
+          "type": "string",
+          "x-go-name": "WalletDriverName"
+        },
+        "wallet_name": {
+          "type": "string",
+          "x-go-name": "WalletName"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "DeleteKeyRequest": {
+      "description": "APIV1DELETEKeyRequest is the request for `DELETE /v1/key`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1DELETEKeyRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "DeleteMultisigRequest": {
+      "description": "APIV1DELETEMultisigRequest is the request for `DELETE /v1/multisig`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1DELETEMultisigRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "Digest": {
+      "type": "array",
+      "title": "Digest represents a 32-byte value holding the 256-bit Hash digest.",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "ExportKeyRequest": {
+      "description": "APIV1POSTKeyExportRequest is the request for `POST /v1/key/export`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTKeyExportRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ExportMasterKeyRequest": {
+      "description": "APIV1POSTMasterKeyExportRequest is the request for `POST /v1/master-key/export`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTMasterKeyExportRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ExportMultisigRequest": {
+      "description": "APIV1POSTMultisigExportRequest is the request for `POST /v1/multisig/export`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTMultisigExportRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "GenerateKeyRequest": {
+      "description": "APIV1POSTKeyRequest is the request for `POST /v1/key`",
+      "type": "object",
+      "properties": {
+        "display_mnemonic": {
+          "type": "boolean",
+          "x-go-name": "DisplayMnemonic"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTKeyRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ImportKeyRequest": {
+      "description": "APIV1POSTKeyImportRequest is the request for `POST /v1/key/import`",
+      "type": "object",
+      "properties": {
+        "private_key": {
+          "$ref": "#/definitions/PrivateKey"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTKeyImportRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ImportMultisigRequest": {
+      "description": "APIV1POSTMultisigImportRequest is the request for `POST /v1/multisig/import`",
+      "type": "object",
+      "properties": {
+        "multisig_version": {
+          "type": "integer",
+          "format": "uint8",
+          "x-go-name": "Version"
+        },
+        "pks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PublicKey"
+          },
+          "x-go-name": "PKs"
+        },
+        "threshold": {
+          "type": "integer",
+          "format": "uint8",
+          "x-go-name": "Threshold"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTMultisigImportRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "InitWalletHandleTokenRequest": {
+      "description": "APIV1POSTWalletInitRequest is the request for `POST /v1/wallet/init`",
+      "type": "object",
+      "properties": {
+        "wallet_id": {
+          "type": "string",
+          "x-go-name": "WalletID"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletInitRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ListKeysRequest": {
+      "description": "APIV1POSTKeyListRequest is the request for `POST /v1/key/list`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTKeyListRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ListMultisigRequest": {
+      "description": "APIV1POSTMultisigListRequest is the request for `POST /v1/multisig/list`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTMultisigListRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ListWalletsRequest": {
+      "description": "APIV1GETWalletsRequest is the request for `GET /v1/wallets`",
+      "type": "object",
+      "x-go-name": "APIV1GETWalletsRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "MasterDerivationKey": {
+      "description": "MasterDerivationKey is used to derive ed25519 keys for use in wallets",
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "MultisigSig": {
+      "description": "MultisigSig is the structure that holds multiple Subsigs",
+      "type": "object",
+      "properties": {
+        "Subsigs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MultisigSubsig"
+          }
+        },
+        "Threshold": {
+          "type": "integer",
+          "format": "uint8"
+        },
+        "Version": {
+          "type": "integer",
+          "format": "uint8"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "MultisigSubsig": {
+      "description": "MultisigSubsig is a struct that holds a pair of public key and signatures\nsignatures may be empty",
+      "type": "object",
+      "properties": {
+        "Key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "Sig": {
+          "$ref": "#/definitions/Signature"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "PrivateKey": {
+      "description": "PrivateKey is an exported ed25519PrivateKey",
+      "$ref": "#/definitions/ed25519PrivateKey"
+    },
+    "PublicKey": {
+      "description": "PublicKey is an exported ed25519PublicKey",
+      "$ref": "#/definitions/ed25519PublicKey"
+    },
+    "ReleaseWalletHandleTokenRequest": {
+      "description": "APIV1POSTWalletReleaseRequest is the request for `POST /v1/wallet/release`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletReleaseRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "RenameWalletRequest": {
+      "description": "APIV1POSTWalletRenameRequest is the request for `POST /v1/wallet/rename`",
+      "type": "object",
+      "properties": {
+        "wallet_id": {
+          "type": "string",
+          "x-go-name": "WalletID"
+        },
+        "wallet_name": {
+          "type": "string",
+          "x-go-name": "NewWalletName"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletRenameRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "RenewWalletHandleTokenRequest": {
+      "description": "APIV1POSTWalletRenewRequest is the request for `POST /v1/wallet/renew`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletRenewRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "SignMultisigRequest": {
+      "description": "APIV1POSTMultisigTransactionSignRequest is the request for `POST /v1/multisig/sign`",
+      "type": "object",
+      "properties": {
+        "partial_multisig": {
+          "$ref": "#/definitions/MultisigSig"
+        },
+        "public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "signer": {
+          "$ref": "#/definitions/Digest"
+        },
+        "transaction": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Transaction"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTMultisigTransactionSignRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "SignProgramMultisigRequest": {
+      "description": "APIV1POSTMultisigProgramSignRequest is the request for `POST /v1/multisig/signprogram`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Program"
+        },
+        "partial_multisig": {
+          "$ref": "#/definitions/MultisigSig"
+        },
+        "public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTMultisigProgramSignRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "SignProgramRequest": {
+      "description": "APIV1POSTProgramSignRequest is the request for `POST /v1/program/sign`",
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string",
+          "x-go-name": "Address"
+        },
+        "data": {
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Program"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTProgramSignRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "SignTransactionRequest": {
+      "description": "APIV1POSTTransactionSignRequest is the request for `POST /v1/transaction/sign`",
+      "type": "object",
+      "properties": {
+        "public_key": {
+          "$ref": "#/definitions/PublicKey"
+        },
+        "transaction": {
+          "description": "Base64 encoding of msgpack encoding of a `Transaction` object\nNote: SDK and goal usually generate `SignedTxn` objects\nin that case, the field `txn` / `Transaction` of the\ngenerated `SignedTxn` object needs to be used",
+          "type": "string",
+          "format": "byte",
+          "x-go-name": "Transaction"
+        },
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        },
+        "wallet_password": {
+          "type": "string",
+          "x-go-name": "WalletPassword"
+        }
+      },
+      "x-go-name": "APIV1POSTTransactionSignRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "Signature": {
+      "description": "A Signature is a cryptographic signature. It proves that a message was\nproduced by a holder of a cryptographic secret.",
+      "$ref": "#/definitions/ed25519Signature"
+    },
+    "TxType": {
+      "description": "TxType is the type of the transaction written to the ledger",
+      "type": "string",
+      "x-go-package": "github.com/algorand/go-algorand/protocol"
+    },
+    "VersionsRequest": {
+      "description": "VersionsRequest is the request for `GET /versions`",
+      "type": "object",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "VersionsResponse": {
+      "description": "VersionsResponse is the response to `GET /versions`\nfriendly:VersionsResponse",
+      "type": "object",
+      "properties": {
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Versions"
+        }
+      },
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "WalletInfoRequest": {
+      "description": "APIV1POSTWalletInfoRequest is the request for `POST /v1/wallet/info`",
+      "type": "object",
+      "properties": {
+        "wallet_handle_token": {
+          "type": "string",
+          "x-go-name": "WalletHandleToken"
+        }
+      },
+      "x-go-name": "APIV1POSTWalletInfoRequest",
+      "x-go-package": "github.com/algorand/go-algorand/daemon/kmd/lib/kmdapi"
+    },
+    "ed25519PrivateKey": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "ed25519PublicKey": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    },
+    "ed25519Signature": {
+      "type": "array",
+      "title": "Classical signatures */",
+      "items": {
+        "type": "integer",
+        "format": "uint8"
+      },
+      "x-go-package": "github.com/algorand/go-algorand/crypto"
+    }
+  },
+  "responses": {
+    "CreateWalletResponse": {
+      "description": "Response to `POST /v1/wallet`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletResponse"
+      }
+    },
+    "DeleteKeyResponse": {
+      "description": "Response to `DELETE /v1/key`",
+      "schema": {
+        "$ref": "#/definitions/APIV1DELETEKeyResponse"
+      }
+    },
+    "DeleteMultisigResponse": {
+      "description": "Response to POST /v1/multisig/delete",
+      "schema": {
+        "$ref": "#/definitions/APIV1DELETEMultisigResponse"
+      }
+    },
+    "ExportKeyResponse": {
+      "description": "Response to `POST /v1/key/export`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTKeyExportResponse"
+      }
+    },
+    "ExportMasterKeyResponse": {
+      "description": "Response to `POST /v1/master-key/export`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMasterKeyExportResponse"
+      }
+    },
+    "ExportMultisigResponse": {
+      "description": "Response to `POST /v1/multisig/export`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMultisigExportResponse"
+      }
+    },
+    "GenerateKeyResponse": {
+      "description": "Response to `POST /v1/key`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTKeyResponse"
+      }
+    },
+    "ImportKeyResponse": {
+      "description": "Response to `POST /v1/key/import`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTKeyImportResponse"
+      }
+    },
+    "ImportMultisigResponse": {
+      "description": "Response to `POST /v1/multisig/import`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMultisigImportResponse"
+      }
+    },
+    "InitWalletHandleTokenResponse": {
+      "description": "Response to `POST /v1/wallet/init`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletInitResponse"
+      }
+    },
+    "ListKeysResponse": {
+      "description": "Response to `POST /v1/key/list`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTKeyListResponse"
+      }
+    },
+    "ListMultisigResponse": {
+      "description": "Response to `POST /v1/multisig/list`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMultisigListResponse"
+      }
+    },
+    "ListWalletsResponse": {
+      "description": "Response to `GET /v1/wallets`",
+      "schema": {
+        "$ref": "#/definitions/APIV1GETWalletsResponse"
+      }
+    },
+    "ReleaseWalletHandleTokenResponse": {
+      "description": "Response to `POST /v1/wallet/release`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletReleaseResponse"
+      }
+    },
+    "RenameWalletResponse": {
+      "description": "Response to `POST /v1/wallet/rename`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletRenameResponse"
+      }
+    },
+    "RenewWalletHandleTokenResponse": {
+      "description": "Response `POST /v1/wallet/renew`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletRenewResponse"
+      }
+    },
+    "SignMultisigResponse": {
+      "description": "Response to `POST /v1/multisig/sign`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMultisigTransactionSignResponse"
+      }
+    },
+    "SignProgramMultisigResponse": {
+      "description": "Response to `POST /v1/multisig/signdata`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTMultisigProgramSignResponse"
+      }
+    },
+    "SignProgramResponse": {
+      "description": "Response to `POST /v1/data/sign`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTProgramSignResponse"
+      }
+    },
+    "SignTransactionResponse": {
+      "description": "Response to `POST /v1/transaction/sign`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTTransactionSignResponse"
+      }
+    },
+    "VersionsResponse": {
+      "description": "Response to `GET /versions`",
+      "schema": {
+        "$ref": "#/definitions/VersionsResponse"
+      }
+    },
+    "WalletInfoResponse": {
+      "description": "Response to `POST /v1/wallet/info`",
+      "schema": {
+        "$ref": "#/definitions/APIV1POSTWalletInfoResponse"
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "description": "Generated header parameter. This value can be found in `/kmd/data/dir/kmd.token`. Example value: '330b2e4fc9b20f4f89812cf87f1dabeb716d23e3f11aec97a61ff5f750563b78'",
+      "type": "apiKey",
+      "name": "X-KMD-API-Token",
+      "in": "header",
+      "x-example": "330b2e4fc9b20f4f89812cf87f1dabeb716d23e3f11aec97a61ff5f750563b78"
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest",
     "_section:utils": "====================== Helper Scripts ======================",
     "generate-opcode-list": "npx tsx scripts/generate-opcode-list.ts",
+    "generate:openapi": "npx tsx scripts/generate-openapi-schemas.ts",
     "update:opcodes": "npx tsx scripts/update-opcodes.ts",
     "update:opcodes:dry-run": "npx tsx scripts/update-opcodes.ts --dry-run",
     "check:opcodes": "npx tsx scripts/update-opcodes.ts --check",

--- a/scripts/generate-openapi-schemas.ts
+++ b/scripts/generate-openapi-schemas.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Vendors the upstream algod/indexer/kmd OpenAPI specs into `openapi/`, rewriting
+ * `info.title` and `info.description` on the way through.
+ *
+ * `starlight-openapi` renders each API's landing page (`/reference/rest-api/<api>`)
+ * from `info` alone, so whatever upstream puts in `info.description` is the entire
+ * page. Upstream ships a single sentence ("API endpoint for algod operations."),
+ * which left those three pages looking empty. Pointing the plugin at a local copy
+ * is the only way to put real content there — the plugin takes a path or URL, not
+ * a parsed document.
+ *
+ * Output is committed, like `opcodes.json`. Run this by hand when upstream changes.
+ */
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+interface Spec {
+  info: { title: string; description?: string; version: string };
+  [key: string]: unknown;
+}
+
+interface ApiConfig {
+  name: string;
+  url: string;
+  title: string;
+  description: string;
+}
+
+const OUT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../openapi');
+
+// Shared tail: every landing page points readers at the sidebar and the overview
+// page, which is where the spec downloads and Scalar/Swagger/Postman links live.
+const footer = (api: string, nav: string) => `
+Every endpoint is listed in the sidebar under **${api}** → ${nav}, one page per
+operation.
+
+Spec downloads (OAS2 and OAS3) and ready-to-run Scalar, Swagger and Postman
+collections are on the [REST API overview](/reference/rest-api/overview).`;
+
+// Sources are unchanged from the pre-vendoring config. kmd stays pinned to a
+// commit because go-algorand master no longer tracks a stable kmd swagger file.
+const APIS: ApiConfig[] = [
+  {
+    name: 'algod',
+    url: 'https://raw.githubusercontent.com/algorand/go-algorand/refs/heads/master/daemon/algod/api/algod.oas3.yml',
+    title: 'Algod REST API',
+    description: `\`algod\` is the Algorand node daemon. Its REST API is how you submit and
+simulate transactions, read accounts, applications, assets and boxes, fetch
+blocks and ledger state, and check node and network status.
+${footer('algod', 'the tag groups')}`,
+  },
+  {
+    name: 'indexer',
+    url: 'https://raw.githubusercontent.com/algorand/indexer/refs/heads/main/api/indexer.oas3.yml',
+    title: 'Indexer REST API',
+    description: `\`algorand-indexer\` serves searchable historical ledger data — accounts,
+assets, applications, blocks and transactions — including the records an
+\`algod\` node no longer holds locally.
+
+The daemon serves its API from the host:port given by \`--server\`, default
+port \`8980\`.
+${footer('indexer', 'the tag groups')}`,
+  },
+  {
+    name: 'kmd',
+    url: 'https://raw.githubusercontent.com/algorand/go-algorand/ad578576ab5f5bfe58a590164903617ecef379e4/daemon/kmd/api/swagger.json',
+    title: 'KMD REST API',
+    description: `\`kmd\` is the Algorand key management daemon. It keeps wallets and private
+keys in a separate process from \`algod\` and signs transactions on request, so
+keys never pass through the node itself.
+${footer('kmd', '**Operations**')}`,
+  },
+];
+
+async function generate() {
+  await mkdir(OUT_DIR, { recursive: true });
+
+  for (const { name, url, title, description } of APIS) {
+    console.log(`Fetching ${name} spec from ${url}`);
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch ${name} spec: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    // algod.oas3.yml and indexer.oas3.yml are JSON despite the extension, and kmd
+    // is Swagger 2.0 JSON. YAML is a JSON superset, so one loader covers all three
+    // and keeps working if upstream ever switches to real YAML.
+    const spec = yaml.load(await response.text()) as Spec;
+
+    spec.info.title = title;
+    spec.info.description = description;
+
+    const outPath = resolve(OUT_DIR, `${name}.json`);
+    await writeFile(outPath, JSON.stringify(spec, null, 2) + '\n', 'utf8');
+    console.log('Wrote', outPath);
+  }
+}
+
+generate().catch(err => {
+  console.error('[generate-openapi-schemas] Failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
the rest-api landing pages have been basically empty since #386 swapped the generated single-page docs for starlight-openapi -- that plugin builds the page from `info` alone, and upstream ships a one-sentence `info.description`, so all you got was a title and a contact email.

so i vendored the three specs into `openapi/` and rewrite `info.title`/`info.description` on the way through. nothing else in the specs is touched, i diffed them to confirm, so the operation pages are byte-identical to before. refresh with `pnpm run generate:openapi`.