### PR TITLE
docs: accurately represent transaction throughput

### DIFF
--- a/src/content/docs/concepts/transactions/blocks.mdx
+++ b/src/content/docs/concepts/transactions/blocks.mdx
@@ -51,7 +51,7 @@ Algorand confirms blocks every 2.82 seconds on average. This means transactions 
 
 ### Throughput
 
-Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Block capacity is bounded by size rather than by a fixed transaction count: each block holds up to 5,000,000 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions that works out to depends on their type and size, so the count varies from block to block. Mainnet blocks have carried tens of thousands of transactions during periods of high activity.
+Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Block capacity is bounded by size rather than by a fixed transaction count: each block holds up to 5,242,880 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions that works out to depends on their type and size, so the count varies from block to block. Mainnet blocks have carried tens of thousands of transactions during periods of high activity.
 
 ### Finality and No Forking
 

--- a/src/content/docs/concepts/transactions/blocks.mdx
+++ b/src/content/docs/concepts/transactions/blocks.mdx
@@ -51,7 +51,7 @@ Algorand confirms blocks every 2.82 seconds on average. This means transactions 
 
 ### Throughput
 
-Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Block capacity is bounded by size rather than by a fixed transaction count: each block holds up to 5 MB of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions that works out to depends on their type and size, so the count varies from block to block. Mainnet blocks have carried tens of thousands of transactions during periods of high activity.
+Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Block capacity is bounded by size rather than by a fixed transaction count: each block holds up to 5,000,000 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions that works out to depends on their type and size, so the count varies from block to block. Mainnet blocks have carried tens of thousands of transactions during periods of high activity.
 
 ### Finality and No Forking
 

--- a/src/content/docs/concepts/transactions/blocks.mdx
+++ b/src/content/docs/concepts/transactions/blocks.mdx
@@ -51,7 +51,7 @@ Algorand confirms blocks every 2.82 seconds on average. This means transactions 
 
 ### Throughput
 
-Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Each block can hold up to 25,000 transactions, which ensures the network can scale to meet growing demand without sacrificing security or decentralization.
+Algorand is designed for high throughput, supporting thousands of transactions per second (TPS). Block capacity is bounded by size rather than by a fixed transaction count: each block holds up to 5 MB of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions that works out to depends on their type and size, so the count varies from block to block. Mainnet blocks have carried tens of thousands of transactions during periods of high activity.
 
 ### Finality and No Forking
 

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -69,10 +69,12 @@ Algorand’s performance has been consistently validated through public mainnet 
 
 #### Throughput
 
+Algorand blocks are bounded by size rather than by a fixed transaction count: each block holds up to 5 MB of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions fit depends on their type and size, so the figures below are notable observed instances rather than hard limits.
+
 Algorand has demonstrated strong performance under sustained load in real-world conditions:
 
 - **5,000–5,700+ sustained TPS (May 2024)** — Community-led stress tests pushed the network to over 5,000 transactions per second sustained across 100+ blocks
-- **34,000+ transactions in a single block (Feb 2025)** — Blocks finalized in under 3 seconds while processing significantly higher-than-average transaction volumes
+- **34,000+ transactions in a single block (Feb 2025)** — A single block finalized in under 3 seconds while carrying significantly higher-than-average transaction volume
 - **14,500+ TPS peak (Dec 2023)** — Mainnet analysis showed short bursts of very high throughput depending on transaction composition
 
 Importantly, these results were achieved on **public mainnet infrastructure**, not isolated test environments.

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -74,7 +74,7 @@ Algorand blocks are bounded by size rather than by a fixed transaction count: ea
 Algorand has demonstrated strong performance under sustained load in real-world conditions:
 
 - **58,888 transactions in a single block (Dec 2022)** — [Block #25836244](https://allo.info/block/25836244) finalized in under 4 seconds
-- **5,000–5,700+ sustained TPS (May 2024)** — Community-led stress tests pushed the network to over 5,000 transactions per second sustained across 100+ blocks
+- **5,000–5,700+ sustained TPS (May 2024)** — Community-led stress tests pushed the network to over 5,000 transactions per second sustained across 100+ blocks (#38,922,601 to #38,922,700)
 - **34,000+ transactions in a single block (Feb 2025)** — A single block finalized in under 3 seconds while carrying significantly higher-than-average transaction volume
 
 Importantly, these results were achieved on **public mainnet infrastructure**, not isolated test environments.

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -75,7 +75,7 @@ Algorand has demonstrated strong performance under sustained load in real-world 
 
 - **58,888 transactions in a single block (Dec 2022)** — [Block #25836244](https://allo.info/block/25836244) finalized in under 4 seconds
 - **5,000–5,700+ sustained TPS (May 2024)** — Community-led stress tests pushed the network to over 5,000 transactions per second sustained across 100+ blocks (#38,922,601 to #38,922,700)
-- **34,000+ transactions in a single block (Feb 2025)** — A single block finalized in under 3 seconds while carrying significantly higher-than-average transaction volume
+- **34,000+ transactions in a single block (Feb 2025)** — [Block #47358864](https://allo.info/block/47358864) finalized in under 3 seconds.
 
 Importantly, these results were achieved on **public mainnet infrastructure**, not isolated test environments.
 

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -73,9 +73,9 @@ Algorand blocks are bounded by size rather than by a fixed transaction count: ea
 
 Algorand has demonstrated strong performance under sustained load in real-world conditions:
 
+- **58,888 transactions in a single block (Dec 2022)** — [Block #25836244](https://allo.info/block/25836244) finalized in under 4 seconds
 - **5,000–5,700+ sustained TPS (May 2024)** — Community-led stress tests pushed the network to over 5,000 transactions per second sustained across 100+ blocks
 - **34,000+ transactions in a single block (Feb 2025)** — A single block finalized in under 3 seconds while carrying significantly higher-than-average transaction volume
-- **14,500+ TPS peak (Dec 2023)** — Mainnet analysis showed short bursts of very high throughput depending on transaction composition
 
 Importantly, these results were achieved on **public mainnet infrastructure**, not isolated test environments.
 

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -69,7 +69,7 @@ Algorand’s performance has been consistently validated through public mainnet 
 
 #### Throughput
 
-Algorand blocks are bounded by size rather than by a fixed transaction count: each block holds up to 5 MB of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions fit depends on their type and size, so the figures below are notable observed instances rather than hard limits.
+Algorand blocks are bounded by size rather than by a fixed transaction count: each block holds up to 5,000,000 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions fit depends on their type and size, so the figures below are notable observed instances rather than hard limits.
 
 Algorand has demonstrated strong performance under sustained load in real-world conditions:
 

--- a/src/content/docs/getting-started/why-algorand.mdx
+++ b/src/content/docs/getting-started/why-algorand.mdx
@@ -69,7 +69,7 @@ Algorand’s performance has been consistently validated through public mainnet 
 
 #### Throughput
 
-Algorand blocks are bounded by size rather than by a fixed transaction count: each block holds up to 5,000,000 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions fit depends on their type and size, so the figures below are notable observed instances rather than hard limits.
+Algorand blocks are bounded by size rather than by a fixed transaction count: each block holds up to 5,242,880 bytes (5 MB) of transaction data, set by the [`MaxTxnBytesPerBlock`](/concepts/protocol/protocol-parameters) consensus parameter. How many transactions fit depends on their type and size, so the figures below are notable observed instances rather than hard limits.
 
 Algorand has demonstrated strong performance under sustained load in real-world conditions:
 


### PR DESCRIPTION
- Replaced "up to 25,000 transactions" with the 5MB block size limit on both pages
- Reframed the throughput figures as observed instances, ordered chronologically
- Swapped the misdated "14,500+ TPS (Dec 2023)" bullet for the block itself — [#25836244](https://allo.info/block/25836244), 58,888 txns, Dec 2022