### PR TITLE
feat: add Twitter/X meta tags

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -232,6 +232,7 @@ export default defineConfig({
       ],
       components: {
         Footer: './src/components/Footer.astro',
+        Head: './src/components/Head.astro',
         Header: './src/components/Header.astro',
         Hero: './src/components/Hero.astro',
         Banner: './src/components/Banner.astro',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -205,7 +205,7 @@ export default defineConfig({
           tag: 'meta',
           attrs: {
             property: 'og:image',
-            content: '/devportal-og.png',
+            content: 'https://dev.algorand.co/devportal-og.png',
           },
         },
         {
@@ -220,6 +220,13 @@ export default defineConfig({
           attrs: {
             property: 'og:image:height',
             content: '1080',
+          },
+        },
+        {
+          tag: 'meta',
+          attrs: {
+            name: 'twitter:image',
+            content: 'https://dev.algorand.co/devportal-og.png',
           },
         },
       ],

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,19 @@
+---
+/**
+ * Head override - extends Starlight's default head with per-page
+ * Twitter/X meta tags. X falls back to og:title/og:description, but
+ * explicit twitter:* tags make the card rendering deterministic and
+ * are picked up by other platforms that only read twitter:* keys.
+ */
+import Default from '@astrojs/starlight/components/Head.astro';
+
+const { entry, siteTitle } = Astro.locals.starlightRoute;
+const { title, description } = entry.data;
+
+const twitterTitle = title ? `${title} | ${siteTitle}` : siteTitle;
+---
+
+<Default><slot /></Default>
+
+<meta name='twitter:title' content={twitterTitle} />
+{description && <meta name='twitter:description' content={description} />}

--- a/src/content/docs/concepts/accounts/post-quantum.mdx
+++ b/src/content/docs/concepts/accounts/post-quantum.mdx
@@ -1,6 +1,6 @@
 ---
 title: Post-Quantum Accounts
-description: How post-quantum accounts secured by Falcon-1024 signatures work on Algorand, and how existing accounts migrate to quantum-safe keys by rekeying.
+description: How post-quantum accounts secured by Falcon-1024 signatures work on Algorand, and how existing accounts migrate by rekeying.
 sidebar:
   label: Post-Quantum Accounts
 ---

--- a/src/content/docs/concepts/accounts/post-quantum.mdx
+++ b/src/content/docs/concepts/accounts/post-quantum.mdx
@@ -1,6 +1,6 @@
 ---
 title: Post-Quantum Accounts
-description: Explains how post-quantum accounts secured by Falcon-1024 signatures work on Algorand, covering the pqsig envelope, address derivation, key generation, fees, and how existing accounts migrate by rekeying.
+description: How post-quantum accounts secured by Falcon-1024 signatures work on Algorand, and how existing accounts migrate to quantum-safe keys by rekeying.
 sidebar:
   label: Post-Quantum Accounts
 ---


### PR DESCRIPTION
- Made `og:image` an absolute URL (X doesn't resolve relative paths) and added `twitter:image`
- New `Head.astro` override adds per-page `twitter:title` / `twitter:description`
- Trimmed post-quantum page description to fit preview limits

Verified on the preview via opengraph.xyz, all green except the image aspect ratio (needs a 1200×630 asset from creative)