### PR TITLE
fix(sdk-list): update .NET SDK links, unnest page in sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -606,11 +606,7 @@ export default defineConfig({
               attrs: { target: '_blank', rel: 'noopener' },
             },
             { slug: 'resources/p2p-func' },
-            {
-              label: 'SDK',
-              collapsed: true,
-              items: [{ slug: 'resources/sdk/sdk-list' }],
-            },
+            { slug: 'resources/sdk/sdk-list' },
           ],
         },
         // Library sidebars — consumed by LibraryDocsSidebar, hidden from main sidebar

--- a/src/content/docs/resources/sdk/sdk-list.mdx
+++ b/src/content/docs/resources/sdk/sdk-list.mdx
@@ -79,12 +79,12 @@ There are also community-supported SDKs available for other languages:
 
 <LinkCard
   title='.NET SDK Repository'
-  href='https://github.com/RileyGe/dotnet-algorand-sdk'
+  href='https://github.com/scholtz/dotnet-algorand-sdk'
   description='.NET SDK for Algorand'
 />
 <LinkCard
   title='.NET SDK Reference'
-  href='https://rileyge.github.io/dotnet-algorand-sdk/api/index.html'
+  href='https://scholtz.github.io/dotnet-algorand-sdk/'
   description='.NET SDK API Documentation for Algorand'
 />
 


### PR DESCRIPTION
# ℹ Overview

Updates the community-maintained .NET SDK links on the **Algorand SDK List** page to Ludo Scholtz's actively maintained fork, and flattens that page's position in the sidebar.

**1. Updated .NET SDK links** — `src/content/docs/resources/sdk/sdk-list.mdx`

| | Before | After |
|---|---|---|
| Repository | `github.com/RileyGe/dotnet-algorand-sdk` | `github.com/scholtz/dotnet-algorand-sdk` |
| Reference | `rileyge.github.io/dotnet-algorand-sdk/api/index.html` | `scholtz.github.io/dotnet-algorand-sdk/` |

Card titles and descriptions are unchanged.

**2. Swept the portal for other .NET SDK references**

Searched all `.md`, `.mdx`, `.astro`, `.ts`, `.tsx`, `.mjs` and `.json` content for `dotnet`, `RileyGe`, `FrankSzendzielarz`, `scholtz`, `.NET` and `C#`. `sdk-list.mdx` was the only page linking to the .NET SDK. The only other hits are two AlgoKit architecture-decision records that mention C#/.NET generically as a language, not the SDK — left untouched, as they're historical documents imported from external repos.

**3. Raised "Algorand SDK List" one level in the sidebar** — `astro.config.mjs`

The page was the sole child of a collapsible `SDK` group under *Additional Resources*. That wrapper is removed, so the page now renders as a direct sibling of the other entries:

> Overview · LiquidAuth · Bridging · x402 on Algorand · Algorand x EVM · Algorand Specifications · Configuring P2P on FUNC · **Algorand SDK List**

The route is unchanged (`/resources/sdk/sdk-list/`), so no redirect is required.

### 📝 Related Issues
--
### ✅ Acceptance:

- [x] Lint passes
- [x] `astro build` succeeds — 1666 pages built, exit 0
- [x] `starlightLinksValidator` reports "All internal links are valid"
- [x] New .NET URLs verified reachable (both HTTP 200)
- [x] Built HTML contains only the new hrefs; zero occurrences of `rileyge`
- [x] Sidebar verified in rendered output — page is flat under *Additional Resources*, `SDK` group gone
- [x] Page URL unchanged, so no redirect needed
