### PR TITLE
ci: drop unsupported --tala flag from D2 install

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -79,7 +79,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install D2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s -- --tala
+        run: curl -fsSL https://d2lang.com/install.sh | sh
 
       - name: Setup Python for importing docs
         uses: actions/setup-python@v6

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install D2
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s -- --tala
+        run: curl -fsSL https://d2lang.com/install.sh | sh
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
# ℹ Overview

The `d2lang.com` install script now **rejects** the `--tala` flag instead of ignoring it, so the `Install D2` step exits `1` and takes down every PR:


TALA was open-sourced and now ships bundled with D2 releases, so upstream removed the separate plugin-install flag ([announcement](https://d2lang.com/blog/tala-is-open-source/)). The rejection is a hard `flag_errusage` call in the current `install.sh`, not a warning.

This drops the flag in both workflows that install D2:

| Workflow | Failing job |
| --- | --- |
| `.github/workflows/acceptance.yml` | `build` |
| `.github/workflows/publish.yaml` | `deploy` |

```diff
-        run: curl -fsSL https://d2lang.com/install.sh | sh -s -- --tala
+        run: curl -fsSL https://d2lang.com/install.sh | sh
```
### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [X] Lint passes
- [ ] `Acceptance / build` reaches `Install D2` and proceeds
- [ ] `Deploy to Cloudflare Pages / deploy` completes and posts a preview URL
